### PR TITLE
docs: Add RN-Integrate suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ yarn add react-native-boost
 
 Then, add the plugin to your Babel configuration (`babel.config.js`):
 
+#### Using RN-Integrate
+```sh
+npx react-native-integrate react-native-boost
+```
+
+#### Manual
+
 ```js
 module.exports = {
   plugins: ['react-native-boost/plugin'],


### PR DESCRIPTION
By using RN-Integrate, extra steps are applied automatically like in Expo CNG. Also makes the project easily upgradable. More info at https://react-native-integrate.github.io/integrate/

Currently the configuration for this library is maintained at https://github.com/react-native-integrate/configs/blob/main/packages/7/6/f/react-native-boost/integrate.yml

You could customize and ship this file with the module as well.