### PR TITLE
feat: skip optimizing Text inside Expo Router Link with `asChild`

### DIFF
--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-alias-as-child/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-alias-as-child/code.js
@@ -1,0 +1,12 @@
+import { Text } from 'react-native';
+import { Link as RouterLink } from 'expo-router';
+
+<>
+  <Text>This should be optimized</Text>
+  <RouterLink asChild>
+    <Text>This should NOT be optimized due to aliased Link asChild</Text>
+  </RouterLink>
+  <RouterLink>
+    <Text>This should be optimized (aliased Link without asChild)</Text>
+  </RouterLink>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-alias-as-child/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-alias-as-child/output.js
@@ -1,0 +1,16 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { Link as RouterLink } from 'expo-router';
+<>
+  <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+    This should be optimized
+  </_NativeText>
+  <RouterLink asChild>
+    <Text>This should NOT be optimized due to aliased Link asChild</Text>
+  </RouterLink>
+  <RouterLink>
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+      This should be optimized (aliased Link without asChild)
+    </_NativeText>
+  </RouterLink>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-false-static/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-false-static/code.js
@@ -1,0 +1,11 @@
+import { Text } from 'react-native';
+import { Link } from 'expo-router';
+
+<>
+  <Link asChild={false}>
+    <Text>This should be optimized because asChild is false</Text>
+  </Link>
+  <Link asChild={true}>
+    <Text>This should NOT be optimized because asChild is true</Text>
+  </Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-false-static/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-false-static/output.js
@@ -1,0 +1,13 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { Link } from 'expo-router';
+<>
+  <Link asChild={false}>
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+      This should be optimized because asChild is false
+    </_NativeText>
+  </Link>
+  <Link asChild={true}>
+    <Text>This should NOT be optimized because asChild is true</Text>
+  </Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-nested-view/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-nested-view/code.js
@@ -1,0 +1,8 @@
+import { Text, View } from 'react-native';
+import { Link } from 'expo-router';
+
+<Link asChild href="/home">
+  <View>
+    <Text>This should be optimized because View is the direct child</Text>
+  </View>
+</Link>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-nested-view/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child-nested-view/output.js
@@ -1,0 +1,10 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { Text, View } from 'react-native';
+import { Link } from 'expo-router';
+<Link asChild href="/home">
+  <View>
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+      This should be optimized because View is the direct child
+    </_NativeText>
+  </View>
+</Link>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child/code.js
@@ -1,0 +1,15 @@
+import { Text } from 'react-native';
+import { Link } from 'expo-router';
+
+<>
+  <Text>This should be optimized</Text>
+  <Link asChild>
+    <Text>This should NOT be optimized due to Link asChild</Text>
+  </Link>
+  <Link>
+    <Text>This should be optimized (Link without asChild)</Text>
+  </Link>
+  <Link href="/home" asChild>
+    <Text>This should NOT be optimized (Link with href and asChild)</Text>
+  </Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-as-child/output.js
@@ -1,0 +1,19 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { Link } from 'expo-router';
+<>
+  <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+    This should be optimized
+  </_NativeText>
+  <Link asChild>
+    <Text>This should NOT be optimized due to Link asChild</Text>
+  </Link>
+  <Link>
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+      This should be optimized (Link without asChild)
+    </_NativeText>
+  </Link>
+  <Link href="/home" asChild>
+    <Text>This should NOT be optimized (Link with href and asChild)</Text>
+  </Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-namespace-as-child/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-namespace-as-child/code.js
@@ -1,0 +1,11 @@
+import { Text } from 'react-native';
+import * as ExpoRouter from 'expo-router';
+
+<>
+  <ExpoRouter.Link asChild href="/home">
+    <Text>This should NOT be optimized for namespace Link asChild</Text>
+  </ExpoRouter.Link>
+  <ExpoRouter.Link href="/home">
+    <Text>This should be optimized without asChild</Text>
+  </ExpoRouter.Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-namespace-as-child/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/expo-router-link-namespace-as-child/output.js
@@ -1,0 +1,13 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import * as ExpoRouter from 'expo-router';
+<>
+  <ExpoRouter.Link asChild href="/home">
+    <Text>This should NOT be optimized for namespace Link asChild</Text>
+  </ExpoRouter.Link>
+  <ExpoRouter.Link href="/home">
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'}>
+      This should be optimized without asChild
+    </_NativeText>
+  </ExpoRouter.Link>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -12,6 +12,7 @@ import {
   isReactNativeImport,
   replaceWithNativeComponent,
   isStringNode,
+  hasExpoRouterLinkAncestorWithAsChild,
 } from '../../utils/common';
 import { RUNTIME_MODULE_NAME } from '../../utils/constants';
 import { ACCESSIBILITY_PROPERTIES } from '../../utils/constants';
@@ -40,6 +41,7 @@ export const textOptimizer: Optimizer = (path, log = () => {}) => {
   if (!isValidJSXComponent(path, 'Text')) return;
   if (!isReactNativeImport(path, 'Text')) return;
   if (hasBlacklistedProperty(path, textBlacklistedProperties)) return;
+  if (hasExpoRouterLinkAncestorWithAsChild(path)) return;
 
   // Verify that the Text only has string children
   const parent = path.parent as t.JSXElement;

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -12,7 +12,7 @@ import {
   isReactNativeImport,
   replaceWithNativeComponent,
   isStringNode,
-  hasExpoRouterLinkAncestorWithAsChild,
+  hasExpoRouterLinkParentWithAsChild,
 } from '../../utils/common';
 import { RUNTIME_MODULE_NAME } from '../../utils/constants';
 import { ACCESSIBILITY_PROPERTIES } from '../../utils/constants';
@@ -41,7 +41,7 @@ export const textOptimizer: Optimizer = (path, log = () => {}) => {
   if (!isValidJSXComponent(path, 'Text')) return;
   if (!isReactNativeImport(path, 'Text')) return;
   if (hasBlacklistedProperty(path, textBlacklistedProperties)) return;
-  if (hasExpoRouterLinkAncestorWithAsChild(path)) return;
+  if (hasExpoRouterLinkParentWithAsChild(path)) return;
 
   // Verify that the Text only has string children
   const parent = path.parent as t.JSXElement;

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -298,3 +298,50 @@ function hasComponentInExpression(expression: t.Expression, componentName: strin
 
   return false;
 }
+
+/**
+ * Checks if the component has an ancestor Link from 'expo-router' with an 'asChild' prop.
+ *
+ * @param path - The path to the JSXOpeningElement.
+ * @returns true if the component has a Link ancestor from expo-router with asChild prop.
+ */
+export const hasExpoRouterLinkAncestorWithAsChild = (path: NodePath<t.JSXOpeningElement>): boolean => {
+  const linkAncestor = path.findParent((parentPath) => {
+    if (!t.isJSXElement(parentPath.node)) return false;
+
+    const openingElement = parentPath.node.openingElement;
+    if (!t.isJSXIdentifier(openingElement.name)) return false;
+
+    const componentName = openingElement.name.name;
+
+    // Check if this is a Link component
+    const binding = parentPath.scope.getBinding(componentName);
+    if (!binding || binding.kind !== 'module') return false;
+
+    const importDeclaration = binding.path.parent;
+    if (!t.isImportDeclaration(importDeclaration)) return false;
+
+    // Check if imported from 'expo-router'
+    if (importDeclaration.source.value !== 'expo-router') return false;
+
+    // Check if it's imported as 'Link'
+    if (t.isImportSpecifier(binding.path.node)) {
+      const imported = binding.path.node.imported;
+      if (t.isIdentifier(imported) && imported.name !== 'Link') return false;
+    } else if (t.isImportDefaultSpecifier(binding.path.node)) {
+      // For default imports, assume it could be Link
+      return false;
+    }
+
+    // Check if this Link has an 'asChild' prop
+    for (const attribute of openingElement.attributes) {
+      if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name, { name: 'asChild' })) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+  return !!linkAncestor;
+};

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -300,48 +300,103 @@ function hasComponentInExpression(expression: t.Expression, componentName: strin
 }
 
 /**
- * Checks if the component has an ancestor Link from 'expo-router' with an 'asChild' prop.
+ * Checks whether the closest JSX element ancestor is expo-router Link with a truthy asChild prop.
  *
- * @param path - The path to the JSXOpeningElement.
- * @returns true if the component has a Link ancestor from expo-router with asChild prop.
+ * We only bail on Text optimization when Link is effectively slotting that Text as the clickable child.
  */
-export const hasExpoRouterLinkAncestorWithAsChild = (path: NodePath<t.JSXOpeningElement>): boolean => {
-  const linkAncestor = path.findParent((parentPath) => {
-    if (!t.isJSXElement(parentPath.node)) return false;
+export const hasExpoRouterLinkParentWithAsChild = (path: NodePath<t.JSXOpeningElement>): boolean => {
+  const textElementPath = path.parentPath;
+  if (!textElementPath.isJSXElement()) return false;
 
-    const openingElement = parentPath.node.openingElement;
-    if (!t.isJSXIdentifier(openingElement.name)) return false;
+  let ancestorPath: NodePath<t.Node> | null = textElementPath.parentPath;
 
-    const componentName = openingElement.name.name;
+  while (ancestorPath) {
+    if (ancestorPath.isJSXElement()) {
+      if (!isExpoRouterLinkElement(ancestorPath)) return false;
 
-    // Check if this is a Link component
-    const binding = parentPath.scope.getBinding(componentName);
+      return hasTruthyAsChildAttribute(ancestorPath.node.openingElement.attributes);
+    }
+
+    ancestorPath = ancestorPath.parentPath;
+  }
+
+  return false;
+};
+
+function isExpoRouterLinkElement(path: NodePath<t.JSXElement>): boolean {
+  const openingElementName = path.node.openingElement.name;
+
+  if (t.isJSXIdentifier(openingElementName)) {
+    const binding = path.scope.getBinding(openingElementName.name);
     if (!binding || binding.kind !== 'module') return false;
+    if (!t.isImportSpecifier(binding.path.node)) return false;
 
     const importDeclaration = binding.path.parent;
-    if (!t.isImportDeclaration(importDeclaration)) return false;
+    if (!t.isImportDeclaration(importDeclaration) || importDeclaration.source.value !== 'expo-router') return false;
 
-    // Check if imported from 'expo-router'
-    if (importDeclaration.source.value !== 'expo-router') return false;
+    const imported = binding.path.node.imported;
+    return t.isIdentifier(imported, { name: 'Link' }) || (t.isStringLiteral(imported) && imported.value === 'Link');
+  }
 
-    // Check if it's imported as 'Link'
-    if (t.isImportSpecifier(binding.path.node)) {
-      const imported = binding.path.node.imported;
-      if (t.isIdentifier(imported) && imported.name !== 'Link') return false;
-    } else if (t.isImportDefaultSpecifier(binding.path.node)) {
-      // For default imports, assume it could be Link
-      return false;
+  if (t.isJSXMemberExpression(openingElementName)) {
+    if (!t.isJSXIdentifier(openingElementName.object)) return false;
+    if (!t.isJSXIdentifier(openingElementName.property, { name: 'Link' })) return false;
+
+    const namespaceBinding = path.scope.getBinding(openingElementName.object.name);
+    if (!namespaceBinding || namespaceBinding.kind !== 'module') return false;
+    if (!t.isImportNamespaceSpecifier(namespaceBinding.path.node)) return false;
+
+    const importDeclaration = namespaceBinding.path.parent;
+    return t.isImportDeclaration(importDeclaration) && importDeclaration.source.value === 'expo-router';
+  }
+
+  return false;
+}
+
+function hasTruthyAsChildAttribute(attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[]): boolean {
+  let asChildAttribute: t.JSXAttribute | undefined;
+
+  for (const attribute of attributes) {
+    if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name, { name: 'asChild' })) {
+      asChildAttribute = attribute;
     }
+  }
 
-    // Check if this Link has an 'asChild' prop
-    for (const attribute of openingElement.attributes) {
-      if (t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name, { name: 'asChild' })) {
-        return true;
-      }
-    }
+  if (!asChildAttribute) return false;
 
-    return false;
-  });
+  return isJSXAttributeValueTruthy(asChildAttribute.value);
+}
 
-  return !!linkAncestor;
-};
+function isJSXAttributeValueTruthy(value: t.JSXAttribute['value']): boolean {
+  if (!value) return true;
+  if (t.isStringLiteral(value)) return value.value.length > 0;
+  if (t.isJSXElement(value) || t.isJSXFragment(value)) return true;
+
+  if (t.isJSXExpressionContainer(value)) {
+    const staticTruthiness = getStaticExpressionTruthiness(value.expression);
+    return staticTruthiness ?? true;
+  }
+
+  return true;
+}
+
+function getStaticExpressionTruthiness(expression: t.Expression | t.JSXEmptyExpression): boolean | undefined {
+  if (t.isJSXEmptyExpression(expression)) return false;
+  if (t.isBooleanLiteral(expression)) return expression.value;
+  if (t.isNullLiteral(expression)) return false;
+  if (t.isStringLiteral(expression)) return expression.value.length > 0;
+  if (t.isNumericLiteral(expression)) return expression.value !== 0 && !Number.isNaN(expression.value);
+  if (t.isBigIntLiteral(expression)) return expression.value !== '0';
+  if (t.isIdentifier(expression, { name: 'undefined' })) return false;
+
+  if (t.isTemplateLiteral(expression) && expression.expressions.length === 0) {
+    return (expression.quasis[0]?.value.cooked ?? '').length > 0;
+  }
+
+  if (t.isUnaryExpression(expression, { operator: '!' })) {
+    const staticTruthiness = getStaticExpressionTruthiness(expression.argument);
+    return staticTruthiness === undefined ? undefined : !staticTruthiness;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Continues the work in PR #13 by @imranbarbhuiya (which can't be merged anymore because it references a target branch that doesn't exist anymore) and closes #12.

Expo Router with `<Link asChild>` forwards press/navigation props to its direct child, and that interaction relies on the `Text` JS wrapper component's behavior. Replacing that direct child Text with NativeText can break link press handling, so we skip that optimization only for that exact case to preserve correctness while keeping other text optimizations.