### PR TITLE
fix(view): bail on unknown ancestors by default and add opt-in flag

### DIFF
--- a/apps/docs/docs/configuration/configure.md
+++ b/apps/docs/docs/configuration/configure.md
@@ -52,6 +52,12 @@ An object specifying which optimizers to enable or disable. The keys are the nam
 - `text`
 - `view`
 
+### `dangerouslyOptimizeViewWithUnknownAncestors`
+
+By default, the View optimizer bails out when it cannot statically prove that all ancestor components are safe. This avoids incorrect optimizations when unresolved ancestors render a `Text` wrapper across file boundaries.
+
+Set this to `true` to opt back into aggressive behavior and optimize `View` even with unresolved ancestors. This can improve optimization coverage, but may introduce behavioral regressions if those unresolved ancestors render `Text`.
+
 ## Enable only in development / production mode
 
 Babel supports overriding / merging the configuration based on the environment. See the Babel documentation [here](https://babeljs.io/docs/options#env) and [here](https://babeljs.io/docs/options#envname).

--- a/packages/react-native-boost/src/plugin/index.ts
+++ b/packages/react-native-boost/src/plugin/index.ts
@@ -16,7 +16,7 @@ export default declare((api) => {
         const logger = options.verbose ? log : () => {};
         if (isIgnoredFile(path, options.ignores ?? [])) return;
         if (options.optimizations?.text !== false) textOptimizer(path, logger);
-        if (options.optimizations?.view !== false) viewOptimizer(path, logger);
+        if (options.optimizations?.view !== false) viewOptimizer(path, logger, options);
       },
     },
   };

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/react-native-namespace-text-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/react-native-namespace-text-ancestor/code.js
@@ -1,0 +1,7 @@
+import * as ReactNative from 'react-native';
+import { View } from 'react-native';
+<ReactNative.Text>
+  <View>
+    <NotOptimized />
+  </View>
+</ReactNative.Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/react-native-namespace-text-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/react-native-namespace-text-ancestor/output.js
@@ -1,0 +1,7 @@
+import * as ReactNative from 'react-native';
+import { View } from 'react-native';
+<ReactNative.Text>
+  <View>
+    <NotOptimized />
+  </View>
+</ReactNative.Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-safe-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-safe-ancestor/code.js
@@ -1,0 +1,7 @@
+import { View } from 'react-native';
+const Wrapper = ({ children }) => <>{children}</>;
+<Wrapper>
+  <View>
+    <Optimized />
+  </View>
+</Wrapper>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-safe-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-safe-ancestor/output.js
@@ -1,0 +1,8 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View } from 'react-native';
+const Wrapper = ({ children }) => <>{children}</>;
+<Wrapper>
+  <_NativeView>
+    <Optimized />
+  </_NativeView>
+</Wrapper>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-unknown-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-unknown-ancestor/code.js
@@ -1,0 +1,7 @@
+import { View } from 'react-native';
+const Wrapper = ({ children }) => <UnknownContainer>{children}</UnknownContainer>;
+<Wrapper>
+  <View>
+    <NotOptimized />
+  </View>
+</Wrapper>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-unknown-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/same-file-unknown-ancestor/output.js
@@ -1,0 +1,7 @@
+import { View } from 'react-native';
+const Wrapper = ({ children }) => <UnknownContainer>{children}</UnknownContainer>;
+<Wrapper>
+  <View>
+    <NotOptimized />
+  </View>
+</Wrapper>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/code.js
@@ -1,0 +1,12 @@
+import { View } from 'react-native';
+import { ExternalWrapper } from './ExternalWrapper';
+<>
+  <View>
+    <Optimized />
+  </View>
+  <ExternalWrapper>
+    <View>
+      <NotOptimized />
+    </View>
+  </ExternalWrapper>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/dangerous-output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/dangerous-output.js
@@ -1,0 +1,13 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View } from 'react-native';
+import { ExternalWrapper } from './ExternalWrapper';
+<>
+  <_NativeView>
+    <Optimized />
+  </_NativeView>
+  <ExternalWrapper>
+    <_NativeView>
+      <NotOptimized />
+    </_NativeView>
+  </ExternalWrapper>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/unknown-imported-ancestor/output.js
@@ -1,0 +1,13 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View } from 'react-native';
+import { ExternalWrapper } from './ExternalWrapper';
+<>
+  <_NativeView>
+    <Optimized />
+  </_NativeView>
+  <ExternalWrapper>
+    <View>
+      <NotOptimized />
+    </View>
+  </ExternalWrapper>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
@@ -13,3 +13,21 @@ pluginTester({
   },
   formatResult: formatTestResult,
 });
+
+pluginTester({
+  plugin: generateTestPlugin(viewOptimizer, {
+    dangerouslyOptimizeViewWithUnknownAncestors: true,
+  }),
+  title: 'view dangerous unknown ancestors',
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+  tests: [
+    {
+      title: 'optimizes View inside unresolved ancestor when enabled',
+      fixture: path.resolve(import.meta.dirname, 'fixtures/unknown-imported-ancestor/code.js'),
+      outputFixture: path.resolve(import.meta.dirname, 'fixtures/unknown-imported-ancestor/dangerous-output.js'),
+    },
+  ],
+});

--- a/packages/react-native-boost/src/plugin/optimizers/view/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/index.ts
@@ -7,7 +7,7 @@ import {
   isValidJSXComponent,
   isReactNativeImport,
   replaceWithNativeComponent,
-  hasComponentAncestor,
+  hasUnsafeViewAncestor,
 } from '../../utils/common';
 
 export const viewBlacklistedProperties = new Set([
@@ -26,15 +26,12 @@ export const viewBlacklistedProperties = new Set([
   'style', // TODO: process style at runtime
 ]);
 
-// Components to skip when checking for indirect Text ancestors
-const skipComponents = ['View', 'Fragment', 'ScrollView', 'FlatList'];
-
-export const viewOptimizer: Optimizer = (path, log = () => {}) => {
+export const viewOptimizer: Optimizer = (path, log = () => {}, options) => {
   if (isIgnoredLine(path)) return;
   if (!isValidJSXComponent(path, 'View')) return;
   if (!isReactNativeImport(path, 'View')) return;
   if (hasBlacklistedProperty(path, viewBlacklistedProperties)) return;
-  if (hasComponentAncestor(path, 'Text', skipComponents)) return;
+  if (hasUnsafeViewAncestor(path, options?.dangerouslyOptimizeViewWithUnknownAncestors === true)) return;
 
   // Extract the file from the Babel hub
   const hub = path.hub as unknown;

--- a/packages/react-native-boost/src/plugin/types/index.ts
+++ b/packages/react-native-boost/src/plugin/types/index.ts
@@ -25,9 +25,20 @@ export interface PluginOptions {
      */
     view?: boolean;
   };
+  /**
+   * Opt-in flag that allows View optimization when ancestor components cannot be statically resolved.
+   *
+   * This may introduce behavioral changes when unresolved ancestors render react-native Text wrappers.
+   * @default false
+   */
+  dangerouslyOptimizeViewWithUnknownAncestors?: boolean;
 }
 
-export type Optimizer = (path: NodePath<t.JSXOpeningElement>, log?: (message: string) => void) => void;
+export type Optimizer = (
+  path: NodePath<t.JSXOpeningElement>,
+  log?: (message: string) => void,
+  options?: PluginOptions
+) => void;
 
 export type HubFile = t.File & {
   opts: {

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -180,121 +180,415 @@ export const isReactNativeImport = (path: NodePath<t.JSXOpeningElement>, expecte
   return false;
 };
 
-/**
- * Checks if any ancestor element is of the specified component type or contains that component type.
- * This function handles both direct ancestors and custom components that may contain the specified component.
- *
- * @param path - The path to the JSXOpeningElement.
- * @param componentName - The name of the component to check for in ancestors.
- * @param skipComponents - Optional array of component names to skip when checking ancestors.
- * @returns true if any ancestor is or contains the specified component.
- */
-export function hasComponentAncestor(
-  path: NodePath<t.JSXOpeningElement>,
-  componentName: string,
-  skipComponents: string[] = ['Fragment']
-): boolean {
-  // Check for direct ancestors of the specified component type
-  const directAncestor = path.findParent((parentPath) => {
-    return (
-      t.isJSXElement(parentPath.node) && t.isJSXIdentifier(parentPath.node.openingElement.name, { name: componentName })
-    );
-  });
+type AncestorClassification = 'safe' | 'text' | 'unknown';
+type ScopeBinding = NonNullable<ReturnType<NodePath<t.Node>['scope']['getBinding']>>;
 
-  if (directAncestor) return true;
+type AncestorAnalysisContext = {
+  componentCache: WeakMap<t.Node, AncestorClassification>;
+  componentInProgress: WeakSet<t.Node>;
+  renderExpressionInProgress: WeakSet<t.Node>;
+};
 
-  // Check for indirect ancestors (custom components that contain the specified component)
-  return !!path.findParent((parentPath) => {
-    // Only check JSX elements
-    if (!t.isJSXElement(parentPath.node)) return false;
+export const hasUnsafeViewAncestor = (path: NodePath<t.JSXOpeningElement>, allowUnknownAncestors = false): boolean => {
+  const classification = classifyViewAncestors(path);
+  if (classification === 'text') return true;
+  if (classification === 'unknown' && !allowUnknownAncestors) return true;
+  return false;
+};
 
-    // Get the component name
-    const openingElement = parentPath.node.openingElement;
-    if (!t.isJSXIdentifier(openingElement.name)) return false;
+function classifyViewAncestors(path: NodePath<t.JSXOpeningElement>): AncestorClassification {
+  const context: AncestorAnalysisContext = {
+    componentCache: new WeakMap<t.Node, AncestorClassification>(),
+    componentInProgress: new WeakSet<t.Node>(),
+    renderExpressionInProgress: new WeakSet<t.Node>(),
+  };
 
-    const ancestorComponentName = openingElement.name.name;
+  let classification: AncestorClassification = 'safe';
+  let ancestorPath: NodePath<t.Node> | null = path.parentPath.parentPath;
 
-    // Skip the component we're looking for
-    if (ancestorComponentName === componentName) {
-      return false;
+  while (ancestorPath) {
+    if (ancestorPath.isJSXElement()) {
+      const ancestorClassification = classifyJSXElementAsAncestor(ancestorPath, context);
+      classification = mergeAncestorClassification(classification, ancestorClassification);
+
+      if (classification === 'text') return classification;
     }
 
-    // Skip components in the skipComponents list
-    if (skipComponents.includes(ancestorComponentName)) {
-      return false;
-    }
+    ancestorPath = ancestorPath.parentPath;
+  }
 
-    // Skip lowercase components (built-in HTML elements)
-    if (ancestorComponentName[0] === ancestorComponentName[0].toLowerCase()) {
-      return false;
-    }
-
-    // Try to find the component definition through variable binding
-    const binding = parentPath.scope.getBinding(ancestorComponentName);
-    if (!binding) return false;
-
-    // Now check the component definition for the specified component
-    if (t.isVariableDeclarator(binding.path.node)) {
-      const init = binding.path.node.init;
-
-      // Handle arrow functions or function expressions
-      if (t.isArrowFunctionExpression(init) || t.isFunctionExpression(init)) {
-        // Check the function body for the specified component
-        return t.isBlockStatement(init.body)
-          ? hasComponentInReturnStatement(init.body, componentName)
-          : hasComponentInExpression(init.body, componentName);
-      }
-    } else if (t.isFunctionDeclaration(binding.path.node)) {
-      // Handle function declarations
-      return hasComponentInReturnStatement(binding.path.node.body, componentName);
-    }
-
-    return false;
-  });
+  return classification;
 }
 
-/**
- * Check if a block statement contains a return statement with the specified component
- *
- * @param blockStatement - The block statement to check
- * @param componentName - The name of the component to look for
- * @returns true if the block statement contains a return with the specified component
- */
-function hasComponentInReturnStatement(blockStatement: t.BlockStatement, componentName: string): boolean {
-  for (const statement of blockStatement.body) {
-    if (
-      t.isReturnStatement(statement) &&
-      statement.argument &&
-      hasComponentInExpression(statement.argument, componentName)
-    ) {
-      return true;
-    }
+function classifyJSXElementAsAncestor(
+  path: NodePath<t.JSXElement>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  const openingElementName = path.node.openingElement.name;
+
+  if (t.isJSXIdentifier(openingElementName)) {
+    return classifyJSXIdentifierAsAncestor(path, openingElementName.name, context);
   }
+
+  if (t.isJSXMemberExpression(openingElementName)) {
+    return classifyJSXMemberExpressionAsAncestor(path, openingElementName);
+  }
+
+  return 'unknown';
+}
+
+function classifyJSXIdentifierAsAncestor(
+  path: NodePath<t.JSXElement>,
+  identifierName: string,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  if (identifierName === 'Fragment') return 'safe';
+
+  const binding = path.scope.getBinding(identifierName);
+  if (!binding) return 'unknown';
+
+  return classifyBindingAsAncestor(binding, context);
+}
+
+function classifyJSXMemberExpressionAsAncestor(
+  path: NodePath<t.JSXElement>,
+  expression: t.JSXMemberExpression
+): AncestorClassification {
+  if (!t.isJSXIdentifier(expression.object) || !t.isJSXIdentifier(expression.property)) {
+    return 'unknown';
+  }
+
+  const binding = path.scope.getBinding(expression.object.name);
+  if (!binding || binding.kind !== 'module' || !t.isImportNamespaceSpecifier(binding.path.node)) {
+    return 'unknown';
+  }
+
+  const importDeclaration = binding.path.parent;
+  if (!t.isImportDeclaration(importDeclaration)) return 'unknown';
+
+  if (importDeclaration.source.value === 'react-native') {
+    return expression.property.name === 'Text' ? 'text' : 'safe';
+  }
+
+  if (importDeclaration.source.value === 'react' && expression.property.name === 'Fragment') {
+    return 'safe';
+  }
+
+  return 'unknown';
+}
+
+function classifyBindingAsAncestor(binding: ScopeBinding, context: AncestorAnalysisContext): AncestorClassification {
+  if (binding.kind === 'module') {
+    return classifyModuleBindingAsAncestor(binding);
+  }
+
+  return classifyLocalBindingAsAncestor(binding, context);
+}
+
+function classifyModuleBindingAsAncestor(binding: ScopeBinding): AncestorClassification {
+  const importDeclaration = binding.path.parent;
+  if (!t.isImportDeclaration(importDeclaration)) return 'unknown';
+
+  const source = importDeclaration.source.value;
+  if (source === 'react-native') {
+    if (t.isImportSpecifier(binding.path.node)) {
+      const importedName = getImportSpecifierImportedName(binding.path.node);
+      if (!importedName) return 'unknown';
+      return importedName === 'Text' ? 'text' : 'safe';
+    }
+
+    if (t.isImportNamespaceSpecifier(binding.path.node)) {
+      return 'safe';
+    }
+
+    return 'unknown';
+  }
+
+  if (source === 'react' && t.isImportSpecifier(binding.path.node)) {
+    const importedName = getImportSpecifierImportedName(binding.path.node);
+    if (importedName === 'Fragment') return 'safe';
+  }
+
+  return 'unknown';
+}
+
+function classifyLocalBindingAsAncestor(
+  binding: ScopeBinding,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  const cacheKey = binding.path.node;
+  const cached = context.componentCache.get(cacheKey);
+  if (cached) return cached;
+
+  if (context.componentInProgress.has(cacheKey)) {
+    return 'unknown';
+  }
+
+  context.componentInProgress.add(cacheKey);
+
+  let classification: AncestorClassification;
+  if (binding.path.isFunctionDeclaration()) {
+    classification = analyzeFunctionComponent(binding.path, context);
+  } else if (binding.path.isVariableDeclarator()) {
+    classification = analyzeVariableDeclaratorComponent(binding.path, context);
+  } else {
+    classification = 'unknown';
+  }
+
+  context.componentInProgress.delete(cacheKey);
+  context.componentCache.set(cacheKey, classification);
+
+  return classification;
+}
+
+function analyzeVariableDeclaratorComponent(
+  path: NodePath<t.VariableDeclarator>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  const initPath = path.get('init');
+  if (!initPath.node) return 'unknown';
+
+  if (initPath.isArrowFunctionExpression() || initPath.isFunctionExpression()) {
+    return analyzeFunctionComponent(initPath, context);
+  }
+
+  if (initPath.isCallExpression()) {
+    return analyzeCallWrappedComponent(initPath, context);
+  }
+
+  if (initPath.isIdentifier()) {
+    const aliasBinding = path.scope.getBinding(initPath.node.name);
+    if (!aliasBinding) return 'unknown';
+
+    return classifyBindingAsAncestor(aliasBinding, context);
+  }
+
+  return 'unknown';
+}
+
+function analyzeCallWrappedComponent(
+  path: NodePath<t.CallExpression>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  if (!isReactMemoOrForwardRefCall(path)) return 'unknown';
+
+  const [firstArgumentPath] = path.get('arguments');
+  if (!firstArgumentPath?.node) return 'unknown';
+
+  if (firstArgumentPath.isArrowFunctionExpression() || firstArgumentPath.isFunctionExpression()) {
+    return analyzeFunctionComponent(firstArgumentPath, context);
+  }
+
+  if (firstArgumentPath.isIdentifier()) {
+    const wrappedComponentBinding = path.scope.getBinding(firstArgumentPath.node.name);
+    if (!wrappedComponentBinding) return 'unknown';
+
+    return classifyBindingAsAncestor(wrappedComponentBinding, context);
+  }
+
+  if (firstArgumentPath.isCallExpression()) {
+    return analyzeCallWrappedComponent(firstArgumentPath, context);
+  }
+
+  return 'unknown';
+}
+
+function isReactMemoOrForwardRefCall(path: NodePath<t.CallExpression>): boolean {
+  const calleePath = path.get('callee');
+
+  if (calleePath.isIdentifier()) {
+    if (!isMemoOrForwardRefName(calleePath.node.name)) return false;
+
+    const binding = path.scope.getBinding(calleePath.node.name);
+    return isReactImportBinding(binding);
+  }
+
+  if (calleePath.isMemberExpression()) {
+    const objectPath = calleePath.get('object');
+    const propertyPath = calleePath.get('property');
+
+    if (!objectPath.isIdentifier() || !propertyPath.isIdentifier()) return false;
+    if (!isMemoOrForwardRefName(propertyPath.node.name)) return false;
+
+    const objectBinding = path.scope.getBinding(objectPath.node.name);
+    return isReactImportBinding(objectBinding);
+  }
+
   return false;
 }
 
-/**
- * Check if an expression contains the specified component
- *
- * @param expression - The expression to check
- * @param componentName - The name of the component to look for
- * @returns true if the expression contains the specified component
- */
-function hasComponentInExpression(expression: t.Expression, componentName: string): boolean {
-  // If directly returning a JSX element
-  if (t.isJSXElement(expression)) {
-    // Check if it's the specified component
-    if (t.isJSXIdentifier(expression.openingElement.name, { name: componentName })) {
-      return true;
+function isMemoOrForwardRefName(name: string): boolean {
+  return name === 'memo' || name === 'forwardRef';
+}
+
+function isReactImportBinding(binding: ScopeBinding | undefined): binding is ScopeBinding {
+  if (!binding || binding.kind !== 'module') return false;
+
+  const importDeclaration = binding.path.parent;
+  return t.isImportDeclaration(importDeclaration) && importDeclaration.source.value === 'react';
+}
+
+function analyzeFunctionComponent(
+  path: NodePath<t.FunctionDeclaration | t.FunctionExpression | t.ArrowFunctionExpression>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  const bodyPath = path.get('body');
+
+  if (!bodyPath.isBlockStatement()) {
+    return analyzeRenderExpression(bodyPath as NodePath<t.Node>, context);
+  }
+
+  let classification: AncestorClassification = 'safe';
+
+  for (const statementPath of bodyPath.get('body')) {
+    if (!statementPath.isReturnStatement()) continue;
+
+    const argumentPath = statementPath.get('argument');
+    if (!argumentPath.node) continue;
+
+    const returnClassification = analyzeRenderExpression(argumentPath as NodePath<t.Node>, context);
+    classification = mergeAncestorClassification(classification, returnClassification);
+
+    if (classification === 'text') return classification;
+  }
+
+  return classification;
+}
+
+function analyzeRenderExpression(path: NodePath<t.Node>, context: AncestorAnalysisContext): AncestorClassification {
+  if (path.isJSXFragment()) {
+    return analyzeJSXChildren(path.get('children'), context);
+  }
+
+  let classification: AncestorClassification = 'safe';
+  let hasJSX = false;
+
+  path.traverse({
+    JSXOpeningElement(jsxPath) {
+      hasJSX = true;
+
+      const jsxElementPath = jsxPath.parentPath;
+      if (!jsxElementPath.isJSXElement()) {
+        classification = mergeAncestorClassification(classification, 'unknown');
+        return;
+      }
+
+      const jsxClassification = classifyJSXElementAsAncestor(jsxElementPath, context);
+      classification = mergeAncestorClassification(classification, jsxClassification);
+
+      if (classification === 'text') {
+        jsxPath.stop();
+      }
+    },
+  });
+
+  if (hasJSX) return classification;
+
+  if (path.isIdentifier()) {
+    return analyzeIdentifierRenderExpression(path, context);
+  }
+
+  if (path.isMemberExpression() && isPropsChildrenMemberExpression(path.node)) {
+    return 'safe';
+  }
+
+  if (
+    path.isNullLiteral() ||
+    path.isBooleanLiteral() ||
+    path.isNumericLiteral() ||
+    path.isStringLiteral() ||
+    path.isBigIntLiteral()
+  ) {
+    return 'safe';
+  }
+
+  return 'unknown';
+}
+
+function analyzeJSXChildren(
+  children: Array<NodePath<t.JSXText | t.JSXExpressionContainer | t.JSXSpreadChild | t.JSXElement | t.JSXFragment>>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  let classification: AncestorClassification = 'safe';
+
+  for (const childPath of children) {
+    if (childPath.isJSXElement()) {
+      const childClassification = classifyJSXElementAsAncestor(childPath, context);
+      classification = mergeAncestorClassification(classification, childClassification);
+    } else if (childPath.isJSXFragment()) {
+      const fragmentClassification = analyzeJSXChildren(childPath.get('children'), context);
+      classification = mergeAncestorClassification(classification, fragmentClassification);
+    } else if (childPath.isJSXExpressionContainer()) {
+      const expressionPath = childPath.get('expression');
+      if (!expressionPath.node || expressionPath.isJSXEmptyExpression()) continue;
+
+      const expressionClassification = analyzeRenderExpression(expressionPath as NodePath<t.Node>, context);
+      classification = mergeAncestorClassification(classification, expressionClassification);
+    } else if (childPath.isJSXSpreadChild()) {
+      classification = mergeAncestorClassification(classification, 'unknown');
     }
 
-    // Check if any children are the specified component
-    for (const child of expression.children) {
-      if (t.isJSXElement(child) && t.isJSXIdentifier(child.openingElement.name, { name: componentName })) {
-        return true;
-      }
+    if (classification === 'text') {
+      return classification;
     }
   }
 
-  return false;
+  return classification;
+}
+
+function analyzeIdentifierRenderExpression(
+  path: NodePath<t.Identifier>,
+  context: AncestorAnalysisContext
+): AncestorClassification {
+  if (path.node.name === 'children') return 'safe';
+
+  const binding = path.scope.getBinding(path.node.name);
+  if (!binding) return 'unknown';
+
+  if (binding.kind === 'param') {
+    return binding.identifier.name === 'children' ? 'safe' : 'unknown';
+  }
+
+  if (!binding.path.isVariableDeclarator()) return 'unknown';
+
+  const cacheKey = binding.path.node;
+  if (context.renderExpressionInProgress.has(cacheKey)) {
+    return 'unknown';
+  }
+
+  const initPath = binding.path.get('init');
+  if (!initPath.node) return 'unknown';
+
+  context.renderExpressionInProgress.add(cacheKey);
+  const classification = analyzeRenderExpression(initPath as NodePath<t.Node>, context);
+  context.renderExpressionInProgress.delete(cacheKey);
+
+  return classification;
+}
+
+function isPropsChildrenMemberExpression(expression: t.MemberExpression): boolean {
+  if (!t.isIdentifier(expression.object, { name: 'props' })) return false;
+  if (!t.isIdentifier(expression.property, { name: 'children' })) return false;
+  return !expression.computed;
+}
+
+function mergeAncestorClassification(
+  current: AncestorClassification,
+  next: AncestorClassification
+): AncestorClassification {
+  if (current === 'text' || next === 'text') return 'text';
+  if (current === 'unknown' || next === 'unknown') return 'unknown';
+  return 'safe';
+}
+
+function getImportSpecifierImportedName(specifier: t.ImportSpecifier): string | undefined {
+  if (t.isIdentifier(specifier.imported)) {
+    return specifier.imported.name;
+  }
+
+  if (t.isStringLiteral(specifier.imported)) {
+    return specifier.imported.value;
+  }
+
+  return undefined;
 }

--- a/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
+++ b/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
@@ -1,7 +1,7 @@
 import { declare } from '@babel/helper-plugin-utils';
-import { Optimizer } from '../types';
+import { Optimizer, PluginOptions } from '../types';
 
-export const generateTestPlugin = (optimizer: Optimizer) => {
+export const generateTestPlugin = (optimizer: Optimizer, options: PluginOptions = {}) => {
   return declare((api) => {
     api.assertVersion(7);
 
@@ -9,7 +9,7 @@ export const generateTestPlugin = (optimizer: Optimizer) => {
       name: 'react-native-boost',
       visitor: {
         JSXOpeningElement(path) {
-          optimizer(path);
+          optimizer(path, undefined, options);
         },
       },
     };


### PR DESCRIPTION
This updates the View optimizer to prioritize correctness when ancestor components cannot be resolved statically and closes #1. Views are now only optimized when ancestor chains are provably safe. If an ancestor is `react-native` Text or unknown, optimization is skipped by default.

To preserve flexibility, this also adds the `dangerouslyOptimizeViewWithUnknownAncestors` config flag if you want the previous aggressive behavior.