### PR TITLE
docs: add JSDoc comments to babel config

### DIFF
--- a/apps/example/babel.config.js
+++ b/apps/example/babel.config.js
@@ -1,3 +1,8 @@
+/**
+ * Babel configuration function that configures presets and plugins for the React Native Boost example application.
+ * @param {object} api - The Babel API object.
+ * @returns {object} The Babel configuration object.
+ */
 module.exports = function (api) {
   api.cache(true);
   return {


### PR DESCRIPTION
### 问题背景
导出的函数缺少文档注释，这降低了代码的可读性和维护性，尤其是在配置文件中，注释有助于开发者快速理解配置逻辑。

### 修改内容
- **修改了什么**：在 `apps/example/babel.config.js` 文件中，为导出的函数添加了JSDoc风格的文档注释。
- **为什么这样改**：提升代码的自文档化程度，使函数的作用、参数和返回值一目了然，从而改善可读性和维护性。
- **对代码质量的提升**：增强了代码的透明度和可维护性，降低了新贡献者的上手难度，符合开源最佳实践。

### 验证方式
- 由于修改仅涉及添加注释，没有改变代码功能，所有现有测试应继续通过（可通过运行现有测试套件验证）。
- 手动检查注释的准确性和格式是否符合JSDoc标准。

### 其他信息
- 没有breaking changes，不影响现有API或功能。
- 不需要更新额外文档，因为修改本身是文档改进。
- 无已知限制，这是一个纯文档优化。