### PR TITLE
feat: add Unistyles v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ If you're using Expo and don't see the `babel.config.js` file, run the following
 npx expo customize babel.config.js
 ```
 
+If you're using Unistyles or Nativewind, refer to additional required setup instructions in [the documentation](https://react-native-boost.oss.kuatsu.de/docs).
+
 Finally, restart your React Native development server and clear the bundler cache:
 
 ```sh

--- a/apps/docs/content/docs/compatibility/unistyles.mdx
+++ b/apps/docs/content/docs/compatibility/unistyles.mdx
@@ -1,31 +1,52 @@
 ---
 title: Unistyles Support
-description: Why React Native Boost and Unistyles are currently incompatible.
+description: Keep Unistyles styling working on Boost-optimized components.
 ---
 
-<Callout type="warn" title="Currently incompatible">
-  React Native Boost and [Unistyles](https://www.unistyl.es) (v3) are currently incompatible. Enabling Boost in a Unistyles project can lead to dynamic styles becoming non-reactive.
+React Native Boost is compatible with react-native-unistyles v3. Previous versions of Unistyles are untested and not officially supported.
+
+## Setup
+
+Enable Boost's Unistyles support layer through the Babel plugin's config options:
+
+```js
+// babel.config.js
+module.exports = {
+  plugins: [
+    ['react-native-boost/plugin', { unistyles: true }],
+    ['react-native-unistyles/plugin', { root: 'src' }],
+  ],
+};
+```
+
+Set `unistyles: false` to turn the mode off, e.g. when Unistyles is installed in your project's dependencies, but not actually used in code. The order of the two plugins does not matter.
+
+<Callout type="info" title="Auto-detection">
+  React Native Boost can auto-detect Unistyles and enable this mode automatically if you haven't explicitly disabled it. However, this auto-detection is fragile and Boost will therefore log a warning to the console. Explicitly set the config flag as shown above to silence the warning.
 </Callout>
 
-## What happens
+## How it works
 
-Unistyles updates styles natively, outside of React. A component only updates if it registers itself
-with Unistyles' native engine at mount. Boost rewrites `Text`/`View` to their native counterparts
-**before** Unistyles can do this, so registration never happens.
+Unistyles updates styles natively, outside of React.
 
-When this happens, the component renders correctly once, then never updates again.
+In Unistyles mode, Boost looks at each `Text`/`View`'s `style` and routes accordingly:
 
-## What breaks
+- **A Unistyles style** (from `StyleSheet.create` imported from `react-native-unistyles`) → rewritten to Unistyles' own lean host, keeping Unistyles' reactivity, while still providing Boost's performance benefits.
+- **A plain React Native style** (an object literal, or a `StyleSheet.create` from `react-native`) →
+  optimized to Boost's standard native host, exactly as in a non-Unistyles app.
+- **A style Boost can't resolve** (e.g. `style={props.style}`, a function call, a conditional) → left
+  untouched. When Boost can't reliably tell if it's a Unistyles style arriving from elsewhere or a plain style object, it has to skip it. When Unistyles mode is disabled, this does not apply, and all components (that don't bail for other reasons) are optimized, no matter where their `style` comes from.
 
-Anything Unistyles drives at runtime stops applying to optimized components:
+### Known limitations
 
-- Theme and color-scheme (light/dark) changes
-- Breakpoint changes (rotation, resize, foldables)
-- Variants, insets, font scale, and other runtime dependencies
+The native components React Native Boost rewrites your components to don't perform some of the prop and style processing the standard JS-based wrapper components do. Without Unistyles, React Native Boost can do this processing for you. With Unistyles, this isn't possible, unfortunately. Therefore:
 
-Note that the initial render looks correct, so the problem is easy to miss in testing.
+| Avoid | Use |
+| --- | --- |
+| `fontWeight: 700` (a number) | `fontWeight: '700'` (a string) |
+| `userSelect: 'none'` | the `selectable` prop, e.g. `selectable={false}` |
+| `verticalAlign: 'middle'` | `textAlignVertical: 'center'` |
 
-## Roadmap
-
-Proper Unistyles support is technically possible and planned. See the [tracking issue #58 on
-GitHub](https://github.com/kuatsu/react-native-boost/issues/58).
+Boost forwards a Unistyles style to the native host untouched (this is what preserves Unistyles'
+reactivity), so the raw forms reach the host as-is. The right-hand values are already in their native
+form, so they work whether or not Unistyles is in play. These only affect `Text`.

--- a/apps/docs/content/docs/configuration/configure.mdx
+++ b/apps/docs/content/docs/configuration/configure.mdx
@@ -18,6 +18,7 @@ module.exports = {
       {
         verbose: false,
         silent: false,
+        unistyles: false,
         ignores: ['node_modules/**'],
         optimizations: {
           text: true,

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -73,6 +73,13 @@ module.exports = {
 };
 ```
 
+If you're using Unistyles or Nativewind in your project, refer to these additional setup instructions:
+
+<Cards>
+  <Card title="Unistyles Support" href="/docs/compatibility/unistyles" />
+  <Card title="Nativewind Support" href="/docs/compatibility/nativewind" />
+</Cards>
+
 4. Restart the development server and clear cache:
 
 <Tabs items={['npm', 'pnpm', 'yarn', 'bun']} groupId="package-manager" persist>

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -14,8 +14,8 @@
     "configuration/configure",
     "configuration/boost-decorator",
     "---Compatibility---",
-    "compatibility/nativewind",
     "compatibility/unistyles",
+    "compatibility/nativewind",
     "compatibility/uniwind",
     "---Runtime Library---",
     "runtime-library/index"

--- a/apps/example/babel.config.js
+++ b/apps/example/babel.config.js
@@ -3,7 +3,19 @@ module.exports = function (api) {
   return {
     presets: ['babel-preset-expo'],
     plugins: [
-      ['react-native-boost/plugin', { ignores: ['node_modules/**', '../../node_modules/**', '**/*.unoptimized.tsx'] }],
+      [
+        'react-native-boost/plugin',
+        {
+          unistyles: true,
+          ignores: ['node_modules/**', '../../node_modules/**', '**/*.unoptimized.tsx'],
+        },
+      ],
+      [
+        'react-native-unistyles/plugin',
+        {
+          root: 'src',
+        },
+      ],
     ],
   };
 };

--- a/apps/example/index.ts
+++ b/apps/example/index.ts
@@ -1,6 +1,7 @@
 // Must be the first import: bakes the benchmark `core` profile's RN feature-flag overrides in before
 // react-native's Text module evaluates (no-op outside the benchmark). See the module's @remarks.
 import './src/benchmark/feature-flags';
+import './src/unistyles';
 
 import { registerRootComponent } from 'expo';
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -25,9 +25,11 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-boost": "workspace:*",
+    "react-native-nitro-modules": "0.35.7",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.23.0",
     "react-native-time-to-render": "workspace:*",
+    "react-native-unistyles": "3.2.5",
     "react-native-web": "^0.21.2"
   },
   "devDependencies": {

--- a/apps/example/src/app.tsx
+++ b/apps/example/src/app.tsx
@@ -8,6 +8,7 @@ import TradingDemoScreen from './screens/trading-demo';
 import LauncherScreen from './screens/launcher';
 import BenchmarkScreen from './screens/benchmark';
 import BenchmarkRunner from './screens/benchmark-runner';
+import UnistylesDemoScreen from './screens/unistyles-demo';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -34,6 +35,7 @@ export default function App() {
             component={TradingDemoScreen}
             options={({ route }) => ({ title: coinsById[route.params.coinId]?.pair ?? 'Price Wall' })}
           />
+          <Stack.Screen name="UnistylesDemo" component={UnistylesDemoScreen} options={{ title: 'Unistyles' }} />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/apps/example/src/navigation.ts
+++ b/apps/example/src/navigation.ts
@@ -4,6 +4,7 @@ export type RootStackParamList = {
   Launcher: undefined;
   Benchmark: undefined;
   TradingDemo: { coinId: string };
+  UnistylesDemo: undefined;
 };
 
 export type RootStackScreenProps<RouteName extends keyof RootStackParamList> = NativeStackScreenProps<

--- a/apps/example/src/screens/launcher.tsx
+++ b/apps/example/src/screens/launcher.tsx
@@ -23,6 +23,16 @@ export default function LauncherScreen({ navigation }: RootStackScreenProps<'Lau
         <Text style={styles.cardTitle}>Mount Benchmark</Text>
         <Text style={styles.cardBody}>Mount thousands of Text and View nodes and measure raw render time.</Text>
       </Pressable>
+
+      <Pressable
+        style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+        onPress={() => navigation.navigate('UnistylesDemo')}>
+        <Text style={styles.cardTitle}>Unistyles Demo</Text>
+        <Text style={styles.cardBody}>
+          Boost-optimized Text and View driven by Unistyles serving as a test screen for Boost's Unistyles support
+          layer.
+        </Text>
+      </Pressable>
     </View>
   );
 }

--- a/apps/example/src/screens/unistyles-demo/index.tsx
+++ b/apps/example/src/screens/unistyles-demo/index.tsx
@@ -13,8 +13,9 @@ export default function UnistylesDemoScreen(_props: RootStackScreenProps<'Unisty
     <View style={styles.screen}>
       <Text style={styles.title}>Unistyles × Boost</Text>
       <Text style={styles.subtitle}>
-        These cards are Boost-optimized and Unistyles-reactive. Toggle the theme or rotate the device: if the colors and
-        layout update, the native registration survived optimization.
+        Every card below is a Boost-optimized host wired to a Unistyles stylesheet. Tap to toggle the theme — they
+        restyle instantly without re-rendering, which is only possible if their native registration survived
+        optimization. The breakpoint styles (column layout, accent color) resolve from the current screen width.
       </Text>
 
       <ThemeToggle />
@@ -102,7 +103,8 @@ const styles = StyleSheet.create((theme) => ({
     gap: theme.gap(1.5),
   },
   card: {
-    flex: 1,
+    flexGrow: 1,
+    flexBasis: 'auto',
     borderRadius: 16,
     padding: theme.gap(2),
     backgroundColor: theme.colors.card,

--- a/apps/example/src/screens/unistyles-demo/index.tsx
+++ b/apps/example/src/screens/unistyles-demo/index.tsx
@@ -1,0 +1,136 @@
+import { Pressable, Text, View } from 'react-native';
+import { StyleSheet, UnistylesRuntime, useUnistyles } from 'react-native-unistyles';
+import { RootStackScreenProps } from '../../navigation';
+
+/**
+ * Boost × Unistyles compatibility probe.
+ *
+ * These subjects do NOT call `useUnistyles`, so they never re-render — any color/layout change after a theme toggle or a
+ * rotation can only come through the native (C++) update path, i.e. the registration Boost preserved.
+ */
+export default function UnistylesDemoScreen(_props: RootStackScreenProps<'UnistylesDemo'>) {
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>Unistyles × Boost</Text>
+      <Text style={styles.subtitle}>
+        These cards are Boost-optimized and Unistyles-reactive. Toggle the theme or rotate the device: if the colors and
+        layout update, the native registration survived optimization.
+      </Text>
+
+      <ThemeToggle />
+      <StatusReadout />
+
+      <View style={styles.row}>
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Card A</Text>
+          <Text style={styles.cardBody}>background and text follow the theme</Text>
+        </View>
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Card B</Text>
+          <Text style={styles.cardBody}>row on wide screens, column on narrow</Text>
+        </View>
+      </View>
+
+      <View style={styles.accentBox}>
+        <Text style={styles.accentText}>Accent box — background is accent on narrow, card on wide</Text>
+      </View>
+    </View>
+  );
+}
+
+function ThemeToggle() {
+  const { rt } = useUnistyles();
+  return (
+    <Pressable
+      style={styles.toggle}
+      onPress={() => UnistylesRuntime.setTheme(rt.themeName === 'dark' ? 'light' : 'dark')}>
+      <Text style={styles.toggleText}>Toggle theme (current: {rt.themeName})</Text>
+    </Pressable>
+  );
+}
+
+function StatusReadout() {
+  const { rt } = useUnistyles();
+  return (
+    <View style={styles.status}>
+      <Text style={styles.statusText}>theme: {rt.themeName}</Text>
+      <Text style={styles.statusText}>breakpoint: {rt.breakpoint}</Text>
+      <Text style={styles.statusText}>width: {Math.round(rt.screen.width)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create((theme) => ({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+    padding: theme.gap(2),
+    gap: theme.gap(1.5),
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  subtitle: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.muted,
+  },
+  toggle: {
+    borderRadius: 12,
+    padding: theme.gap(1.5),
+    backgroundColor: theme.colors.accent,
+    alignItems: 'center',
+  },
+  toggleText: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  status: {
+    flexDirection: 'row',
+    gap: theme.gap(2),
+    paddingVertical: theme.gap(1),
+  },
+  statusText: {
+    fontSize: 13,
+    color: theme.colors.muted,
+  },
+  row: {
+    flexDirection: { xs: 'column', md: 'row' },
+    gap: theme.gap(1.5),
+  },
+  card: {
+    flex: 1,
+    borderRadius: 16,
+    padding: theme.gap(2),
+    backgroundColor: theme.colors.card,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.border,
+    minHeight: 96,
+    gap: theme.gap(0.5),
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: theme.colors.text,
+  },
+  cardBody: {
+    fontSize: 13,
+    color: theme.colors.muted,
+  },
+  accentBox: {
+    borderRadius: 12,
+    padding: theme.gap(2),
+    backgroundColor: {
+      xs: theme.colors.accent,
+      md: theme.colors.card,
+    },
+  },
+  accentText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: theme.colors.text,
+  },
+}));

--- a/apps/example/src/unistyles.ts
+++ b/apps/example/src/unistyles.ts
@@ -1,0 +1,57 @@
+import { StyleSheet } from 'react-native-unistyles';
+
+const lightTheme = {
+  colors: {
+    background: '#ffffff',
+    card: '#f2f4f7',
+    border: '#d9dee5',
+    text: '#0b0e11',
+    muted: '#5b6470',
+    accent: '#2962ff',
+  },
+  gap: (v: number) => v * 8,
+};
+
+const darkTheme = {
+  colors: {
+    background: '#0b0e11',
+    card: '#12161c',
+    border: '#2a3139',
+    text: '#eaecef',
+    muted: '#9aa3ad',
+    accent: '#f0b90b',
+  },
+  gap: (v: number) => v * 8,
+};
+
+const appThemes = {
+  light: lightTheme,
+  dark: darkTheme,
+};
+
+const breakpoints = {
+  xs: 0,
+  sm: 380,
+  md: 600,
+  lg: 900,
+  xl: 1200,
+};
+
+type AppThemes = typeof appThemes;
+type AppBreakpoints = typeof breakpoints;
+
+/* oxlint-disable no-empty-object-type */
+declare module 'react-native-unistyles' {
+  export interface UnistylesThemes extends AppThemes {}
+  export interface UnistylesBreakpoints extends AppBreakpoints {}
+}
+/* oxlint-enable no-empty-object-type */
+
+StyleSheet.configure({
+  settings: {
+    initialTheme: 'dark',
+    adaptiveThemes: false,
+  },
+  breakpoints,
+  themes: appThemes,
+});

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/cascades-view-text/code.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/cascades-view-text/code.js
@@ -1,0 +1,11 @@
+import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ box: { flex: 1 }, t: {} });
+const C = () => (
+  <View style={styles.box}>
+    <Text style={styles.t}>top</Text>
+    <View style={styles.box}>
+      <Text style={styles.t}>deep</Text>
+    </View>
+  </View>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/cascades-view-text/output.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/cascades-view-text/output.js
@@ -1,0 +1,31 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import _UnistylesNativeView from 'react-native-unistyles/components/native/NativeView';
+import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  box: {
+    flex: 1,
+  },
+  t: {},
+});
+const C = () => (
+  <_UnistylesNativeView style={styles.box}>
+    <_UnistylesNativeText
+      style={styles.t}
+      allowFontScaling={true}
+      ellipsizeMode={'tail'}
+      accessible={_getDefaultTextAccessible()}>
+      top
+    </_UnistylesNativeText>
+    <_UnistylesNativeView style={styles.box}>
+      <_UnistylesNativeText
+        style={styles.t}
+        allowFontScaling={true}
+        ellipsizeMode={'tail'}
+        accessible={_getDefaultTextAccessible()}>
+        deep
+      </_UnistylesNativeText>
+    </_UnistylesNativeView>
+  </_UnistylesNativeView>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/mixed-origins-under-lean-view/code.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/mixed-origins-under-lean-view/code.js
@@ -1,0 +1,10 @@
+import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ box: {}, label: {} });
+const C = (props) => (
+  <View style={styles.box}>
+    <Text style={styles.label}>unistyles</Text>
+    <Text style={{ color: 'red' }}>plain literal</Text>
+    <Text style={props.style}>unknown bails</Text>
+  </View>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/mixed-origins-under-lean-view/output.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting-unistyles/mixed-origins-under-lean-view/output.js
@@ -1,0 +1,31 @@
+import { NativeText as _NativeText } from 'react-native-boost/runtime';
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import _UnistylesNativeView from 'react-native-unistyles/components/native/NativeView';
+import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  box: {},
+  label: {},
+});
+const C = (props) => (
+  <_UnistylesNativeView style={styles.box}>
+    <_UnistylesNativeText
+      style={styles.label}
+      allowFontScaling={true}
+      ellipsizeMode={'tail'}
+      accessible={_getDefaultTextAccessible()}>
+      unistyles
+    </_UnistylesNativeText>
+    <_NativeText
+      style={{
+        color: 'red',
+      }}
+      allowFontScaling={true}
+      ellipsizeMode={'tail'}
+      accessible={_getDefaultTextAccessible()}>
+      plain literal
+    </_NativeText>
+    <Text style={props.style}>unknown bails</Text>
+  </_UnistylesNativeView>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/cascades-view-text/code.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/cascades-view-text/code.js
@@ -1,0 +1,9 @@
+import { Text, View } from 'react-native';
+const C = () => (
+  <View style={{ flex: 1 }}>
+    <Text>top</Text>
+    <View style={{ gap: 4 }}>
+      <Text>deep</Text>
+    </View>
+  </View>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/cascades-view-text/output.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/cascades-view-text/output.js
@@ -1,0 +1,24 @@
+import {
+  NativeView as _NativeView,
+  getDefaultTextAccessible as _getDefaultTextAccessible,
+  NativeText as _NativeText,
+} from 'react-native-boost/runtime';
+import { Text, View } from 'react-native';
+const C = () => (
+  <_NativeView
+    style={{
+      flex: 1,
+    }}>
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'} accessible={_getDefaultTextAccessible()}>
+      top
+    </_NativeText>
+    <_NativeView
+      style={{
+        gap: 4,
+      }}>
+      <_NativeText allowFontScaling={true} ellipsizeMode={'tail'} accessible={_getDefaultTextAccessible()}>
+        deep
+      </_NativeText>
+    </_NativeView>
+  </_NativeView>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/text-in-text-stays-bailed/code.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/text-in-text-stays-bailed/code.js
@@ -1,0 +1,7 @@
+import { Text } from 'react-native';
+const C = () => (
+  <Text>
+    outer
+    <Text>inner</Text>
+  </Text>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/text-in-text-stays-bailed/output.js
+++ b/packages/react-native-boost/src/plugin/__tests__/fixtures-nesting/text-in-text-stays-bailed/output.js
@@ -1,0 +1,7 @@
+import { Text } from 'react-native';
+const C = () => (
+  <Text>
+    outer
+    <Text>inner</Text>
+  </Text>
+);

--- a/packages/react-native-boost/src/plugin/__tests__/nesting.test.ts
+++ b/packages/react-native-boost/src/plugin/__tests__/nesting.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { pluginTester } from 'babel-plugin-tester';
+import { generateCombinedTestPlugin } from '../utils/generate-test-plugin';
+import { formatTestResult } from '../utils/format-test-result';
+
+// These run BOTH optimizers per element (like the real plugin), which is required to exercise nested
+// optimization: an outer `View` is rewritten first, then inner elements must recognize that rewritten
+// host as a safe ancestor and keep optimizing down the tree.
+pluginTester({
+  plugin: generateCombinedTestPlugin(),
+  title: 'nesting',
+  fixtures: path.resolve(import.meta.dirname, 'fixtures-nesting'),
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+});
+
+pluginTester({
+  plugin: generateCombinedTestPlugin({ unistyles: true }),
+  title: 'nesting unistyles',
+  fixtures: path.resolve(import.meta.dirname, 'fixtures-nesting-unistyles'),
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+});

--- a/packages/react-native-boost/src/plugin/index.ts
+++ b/packages/react-native-boost/src/plugin/index.ts
@@ -4,6 +4,7 @@ import { PluginLogger, PluginOptions } from './types';
 import { createLogger } from './utils/logger';
 import { viewOptimizer } from './optimizers/view';
 import { isIgnoredFile } from './utils/common';
+import { isUnistylesInstalled } from './utils/unistyles';
 
 export type { PluginOptimizationOptions, PluginOptions } from './types';
 
@@ -12,24 +13,42 @@ type PluginState = {
   __reactNativeBoostLogger?: PluginLogger;
 };
 
-export default declare((api) => {
+export default declare((api, rawOptions, dirname?: string) => {
   api.assertVersion(7);
+
+  const options = (rawOptions ?? {}) as PluginOptions;
 
   // Target platform, resolved at build time. Metro sets this on the Babel caller per platform bundle,
   // letting optimizers inline platform-specific defaults instead of deferring them to the runtime.
   const platform = api.caller((caller) => (caller as { platform?: string } | undefined)?.platform);
+
+  // Resolve "Unistyles mode" once per plugin instance. An explicit `unistyles` flag always wins;
+  // otherwise auto-detect an installed `react-native-unistyles` and, when found, enable the mode but
+  // hint (once) to set the flag explicitly — a detected package does not prove its Babel plugin is active.
+  const autoDetectedUnistyles = options.unistyles === undefined && isUnistylesInstalled(dirname);
+  const unistylesEnabled = options.unistyles === true || autoDetectedUnistyles;
+  let unistylesHintLogged = false;
 
   return {
     name: 'react-native-boost',
     visitor: {
       JSXOpeningElement(path, state) {
         const pluginState = state as PluginState;
-        const options = (pluginState.opts ?? {}) as PluginOptions;
         const logger = getOrCreateLogger(pluginState, options);
 
+        if (autoDetectedUnistyles && !unistylesHintLogged) {
+          unistylesHintLogged = true;
+          logger.warning({
+            message:
+              'react-native-unistyles was detected, so Unistyles mode was enabled automatically. Set ' +
+              '`unistyles: true` in the react-native-boost plugin options to make this explicit, or ' +
+              '`unistyles: false` to opt out.',
+          });
+        }
+
         if (isIgnoredFile(path, options.ignores ?? [])) return;
-        if (options.optimizations?.text !== false) textOptimizer(path, logger, options, platform);
-        if (options.optimizations?.view !== false) viewOptimizer(path, logger, options);
+        if (options.optimizations?.text !== false) textOptimizer(path, logger, options, platform, unistylesEnabled);
+        if (options.optimizations?.view !== false) viewOptimizer(path, logger, options, platform, unistylesEnabled);
       },
     },
   };

--- a/packages/react-native-boost/src/plugin/index.ts
+++ b/packages/react-native-boost/src/plugin/index.ts
@@ -24,10 +24,18 @@ export default declare((api, rawOptions, dirname?: string) => {
 
   // Resolve "Unistyles mode" once per plugin instance. An explicit `unistyles` flag always wins;
   // otherwise auto-detect an installed `react-native-unistyles` and, when found, enable the mode but
-  // hint (once) to set the flag explicitly — a detected package does not prove its Babel plugin is active.
+  // hint to set the flag explicitly — a detected package does not prove its Babel plugin is active.
   const autoDetectedUnistyles = options.unistyles === undefined && isUnistylesInstalled(dirname);
   const unistylesEnabled = options.unistyles === true || autoDetectedUnistyles;
-  let unistylesHintLogged = false;
+
+  if (autoDetectedUnistyles) {
+    createLogger({ verbose: options.verbose === true, silent: options.silent === true }).warning({
+      message:
+        'react-native-unistyles was detected, so Unistyles mode was enabled automatically. Set ' +
+        '`unistyles: true` in the react-native-boost plugin options to make this explicit, or ' +
+        '`unistyles: false` to opt out.',
+    });
+  }
 
   return {
     name: 'react-native-boost',
@@ -35,16 +43,6 @@ export default declare((api, rawOptions, dirname?: string) => {
       JSXOpeningElement(path, state) {
         const pluginState = state as PluginState;
         const logger = getOrCreateLogger(pluginState, options);
-
-        if (autoDetectedUnistyles && !unistylesHintLogged) {
-          unistylesHintLogged = true;
-          logger.warning({
-            message:
-              'react-native-unistyles was detected, so Unistyles mode was enabled automatically. Set ' +
-              '`unistyles: true` in the react-native-boost plugin options to make this explicit, or ' +
-              '`unistyles: false` to opt out.',
-          });
-        }
 
         if (isIgnoredFile(path, options.ignores ?? [])) return;
         if (options.optimizations?.text !== false) textOptimizer(path, logger, options, platform, unistylesEnabled);

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles-ts/unistyles-cast-style/code.tsx
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles-ts/unistyles-cast-style/code.tsx
@@ -1,0 +1,4 @@
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+<Text style={styles.text as TextStyle}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles-ts/unistyles-cast-style/output.tsx
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles-ts/unistyles-cast-style/output.tsx
@@ -1,0 +1,16 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+<_UnistylesNativeText
+  style={styles.text as TextStyle}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_UnistylesNativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-aliased-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-aliased-style/code.js
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+const textStyle = styles.text;
+<Text style={textStyle}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-aliased-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-aliased-style/output.js
@@ -1,0 +1,17 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+const textStyle = styles.text;
+<_UnistylesNativeText
+  style={textStyle}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_UnistylesNativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-imported-style-bails/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-imported-style-bails/code.js
@@ -1,0 +1,3 @@
+import { Text } from 'react-native';
+import { styles } from './styles';
+<Text style={styles.text}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-imported-style-bails/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-imported-style-bails/output.js
@@ -1,0 +1,3 @@
+import { Text } from 'react-native';
+import { styles } from './styles';
+<Text style={styles.text}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-literal-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-literal-style/code.js
@@ -1,0 +1,2 @@
+import { Text } from 'react-native';
+<Text style={{ color: 'red' }}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-literal-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-literal-style/output.js
@@ -1,0 +1,14 @@
+import {
+  getDefaultTextAccessible as _getDefaultTextAccessible,
+  NativeText as _NativeText,
+} from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+<_NativeText
+  style={{
+    color: 'red',
+  }}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_NativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-no-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-no-style/code.js
@@ -1,0 +1,2 @@
+import { Text } from 'react-native';
+<Text>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-no-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-no-style/output.js
@@ -1,0 +1,8 @@
+import {
+  getDefaultTextAccessible as _getDefaultTextAccessible,
+  NativeText as _NativeText,
+} from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+<_NativeText allowFontScaling={true} ellipsizeMode={'tail'} accessible={_getDefaultTextAccessible()}>
+  Hello
+</_NativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-optional-member-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-optional-member-style/code.js
@@ -1,0 +1,4 @@
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+<Text style={styles?.text}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-optional-member-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-optional-member-style/output.js
@@ -1,0 +1,16 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+<_UnistylesNativeText
+  style={styles?.text}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_UnistylesNativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-plain-rn-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-plain-rn-style/code.js
@@ -1,0 +1,3 @@
+import { Text, StyleSheet } from 'react-native';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+<Text style={styles.text}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-plain-rn-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-plain-rn-style/output.js
@@ -1,0 +1,18 @@
+import {
+  processTextStyle as _processTextStyle,
+  getDefaultTextAccessible as _getDefaultTextAccessible,
+  NativeText as _NativeText,
+} from 'react-native-boost/runtime';
+import { Text, StyleSheet } from 'react-native';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+<_NativeText
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  {..._processTextStyle(styles.text)}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_NativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style-array/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style-array/code.js
@@ -1,0 +1,4 @@
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+<Text style={[styles.text, { margin: 4 }]}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style-array/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style-array/output.js
@@ -1,0 +1,21 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+<_UnistylesNativeText
+  style={[
+    styles.text,
+    {
+      margin: 4,
+    },
+  ]}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_UnistylesNativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style/code.js
@@ -1,0 +1,4 @@
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ text: { color: 'red' } });
+<Text style={styles.text}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-style/output.js
@@ -1,0 +1,16 @@
+import { NativeText as _UnistylesNativeText } from 'react-native-unistyles/components/native/NativeText';
+import { getDefaultTextAccessible as _getDefaultTextAccessible } from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  text: {
+    color: 'red',
+  },
+});
+<_UnistylesNativeText
+  style={styles.text}
+  allowFontScaling={true}
+  ellipsizeMode={'tail'}
+  accessible={_getDefaultTextAccessible()}>
+  Hello
+</_UnistylesNativeText>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/code.js
@@ -1,0 +1,2 @@
+import { Text } from 'react-native';
+<Text style={props.style}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/output.js
@@ -1,0 +1,2 @@
+import { Text } from 'react-native';
+<Text style={props.style}>Hello</Text>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
@@ -51,3 +51,13 @@ pluginTester({
   },
   formatResult: formatTestResult,
 });
+
+pluginTester({
+  plugin: generateTestPlugin(textOptimizer, { unistyles: true }),
+  title: 'text unistyles typescript',
+  fixtures: path.resolve(import.meta.dirname, 'fixtures-unistyles-ts'),
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx', ['@babel/plugin-syntax-typescript', { isTSX: true }]],
+  },
+  formatResult: formatTestResult,
+});

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
@@ -41,3 +41,13 @@ pluginTester({
     outputFixture: path.resolve(import.meta.dirname, `fixtures/${name}/dangerous-output.js`),
   })),
 });
+
+pluginTester({
+  plugin: generateTestPlugin(textOptimizer, { unistyles: true }),
+  title: 'text unistyles',
+  fixtures: path.resolve(import.meta.dirname, 'fixtures-unistyles'),
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+});

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -24,8 +24,9 @@ import {
   tryBuildStaticTextStyle,
   ancestorBailoutChecks,
   createStyleOriginResolver,
+  UNISTYLES_TEXT_HOST,
 } from '../../utils/common';
-import { ACCESSIBILITY_PROPERTIES, RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_TEXT_MODULE } from '../../utils/constants';
+import { ACCESSIBILITY_PROPERTIES, RUNTIME_MODULE_NAME } from '../../utils/constants';
 
 export const textBlacklistedProperties = new Set([
   'onLongPress',
@@ -169,15 +170,7 @@ export const textOptimizer: Optimizer = (path, logger, options, platform, unisty
   // A Unistyles-styled Text routes to Unistyles' lean host (a registering wrapper around `RCTText`); its
   // `style` is passed by identity (see `processProps`) so the Unistyles native-state — and therefore the
   // shadow-tree registration — survives. Plain text optimizes to Boost's own raw host as usual.
-  if (routeToUnistyles) {
-    replaceWithNativeComponent(path, parent, file, 'NativeText', {
-      moduleName: UNISTYLES_NATIVE_TEXT_MODULE,
-      importName: 'NativeText',
-      nameHint: 'UnistylesNativeText',
-    });
-  } else {
-    replaceWithNativeComponent(path, parent, file, 'NativeText');
-  }
+  replaceWithNativeComponent(path, parent, file, 'NativeText', routeToUnistyles ? UNISTYLES_TEXT_HOST : undefined);
 };
 
 /**

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -23,8 +23,10 @@ import {
   extractSelectableAndUpdateStyle,
   tryBuildStaticTextStyle,
   ancestorBailoutChecks,
+  classifyStyleOrigin,
+  StyleOrigin,
 } from '../../utils/common';
-import { ACCESSIBILITY_PROPERTIES, RUNTIME_MODULE_NAME } from '../../utils/constants';
+import { ACCESSIBILITY_PROPERTIES, RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_TEXT_MODULE } from '../../utils/constants';
 
 export const textBlacklistedProperties = new Set([
   'onLongPress',
@@ -82,12 +84,20 @@ const TEXT_SPREAD_GUARD_KEYS = new Set([
 const isNormalizedProperty = (attribute: t.JSXAttribute | t.JSXSpreadAttribute): attribute is t.JSXAttribute =>
   t.isJSXAttribute(attribute) && t.isJSXIdentifier(attribute.name) && NORMALIZED_PROPERTIES.has(attribute.name.name);
 
-export const textOptimizer: Optimizer = (path, logger, options, platform) => {
+export const textOptimizer: Optimizer = (path, logger, options, platform, unistylesEnabled) => {
   if (!isValidJSXComponent(path, 'Text')) return;
   if (!isReactNativeImport(path, 'Text')) return;
 
   const parent = path.parent as t.JSXElement;
   const forced = isForcedLine(path);
+
+  // In Unistyles mode, classify the direct `style` origin (lazily, once). A `style` carried by a spread
+  // is already guarded (`style` ∈ TEXT_SPREAD_GUARD_KEYS), so only the direct attribute is classified.
+  let styleOrigin: StyleOrigin | undefined;
+  const getStyleOrigin = (): StyleOrigin => {
+    if (!unistylesEnabled) return 'plain';
+    return (styleOrigin ??= classifyStyleOrigin(path, extractStyleAttribute(path.node.attributes).styleExpr));
+  };
 
   const overridableChecks: BailoutCheck[] = [
     {
@@ -97,6 +107,10 @@ export const textOptimizer: Optimizer = (path, logger, options, platform) => {
     {
       reason: 'has a spread that may carry a translated, normalized, or clamped prop',
       shouldBail: () => hasBlacklistedPropertyInSpread(path, TEXT_SPREAD_GUARD_KEYS),
+    },
+    {
+      reason: 'has an unresolved style source that may be a Unistyles style',
+      shouldBail: () => getStyleOrigin() === 'unknown',
     },
     {
       reason: 'has both a dynamic `id` and a `nativeID` (ambiguous precedence)',
@@ -148,15 +162,27 @@ export const textOptimizer: Optimizer = (path, logger, options, platform) => {
     path,
   });
 
+  const routeToUnistyles = getStyleOrigin() === 'unistyles';
+
   // Process props
   fixNegativeNumberOfLines({ path, logger, file });
   renameIdToNativeID(path);
   addDefaultProperty(path, 'allowFontScaling', t.booleanLiteral(true));
   addDefaultProperty(path, 'ellipsizeMode', t.stringLiteral('tail'));
-  processProps(path, file, platform);
+  processProps(path, file, platform, routeToUnistyles);
 
-  // Replace the Text component with NativeText
-  replaceWithNativeComponent(path, parent, file, 'NativeText');
+  // A Unistyles-styled Text routes to Unistyles' lean host (a registering wrapper around `RCTText`); its
+  // `style` is passed by identity (see `processProps`) so the Unistyles native-state — and therefore the
+  // shadow-tree registration — survives. Plain text optimizes to Boost's own raw host as usual.
+  if (routeToUnistyles) {
+    replaceWithNativeComponent(path, parent, file, 'NativeText', {
+      moduleName: UNISTYLES_NATIVE_TEXT_MODULE,
+      importName: 'NativeText',
+      nameHint: 'UnistylesNativeText',
+    });
+  } else {
+    replaceWithNativeComponent(path, parent, file, 'NativeText');
+  }
 };
 
 /**
@@ -252,8 +278,21 @@ function staticNumberOfLines(expression: t.Expression): number | undefined {
 
 /**
  * Processes style and accessibility attributes, replacing them with optimized versions.
+ *
+ * When `passStyleByIdentity` is set (Unistyles routing), the `style` attribute is left exactly as
+ * written instead of being flattened/normalized through `processTextStyle` — flattening would strip the
+ * Unistyles native-state the engine needs. Accessibility, `selectionColor`, and the `accessible` default
+ * are still applied (they do not touch `style`). The skipped text normalizations (numeric `fontWeight`,
+ * `verticalAlign`, `userSelect` → `selectable`) cannot be reproduced safely here: for a reactive style
+ * Unistyles' C++ engine re-commits the raw parsed values on every update, overwriting any JS-side
+ * normalization, so matching Unistyles' own lean-host semantics (raw pass-through) is the correct contract.
  */
-function processProps(path: NodePath<t.JSXOpeningElement>, file: HubFile, platform?: string) {
+function processProps(
+  path: NodePath<t.JSXOpeningElement>,
+  file: HubFile,
+  platform?: string,
+  passStyleByIdentity = false
+) {
   // Grab the up-to-date list of attributes
   const currentAttributes = [...path.node.attributes];
 
@@ -300,7 +339,9 @@ function processProps(path: NodePath<t.JSXOpeningElement>, file: HubFile, platfo
   let selectableAttribute: t.JSXAttribute | undefined;
   let staticStyleAttribute: t.JSXAttribute | undefined;
   let styleSpread: t.JSXSpreadAttribute | undefined;
-  if (styleExpr) {
+  // `passStyleByIdentity` (Unistyles routing) skips all style transforms — the original `style`
+  // attribute is left untouched in the collected attributes below so it reaches the native host intact.
+  if (styleExpr && !passStyleByIdentity) {
     const selectableValue = extractSelectableAndUpdateStyle(styleExpr);
 
     if (selectableValue != null) {
@@ -357,8 +398,9 @@ function processProps(path: NodePath<t.JSXOpeningElement>, file: HubFile, platfo
   const remainingAttributes: (t.JSXAttribute | t.JSXSpreadAttribute)[] = [];
 
   for (const attribute of currentAttributes) {
-    // Skip the style attribute (we have replaced it with a `style` object or `processTextStyle` spread)
-    if (styleAttribute && attribute === styleAttribute) continue;
+    // Skip the style attribute (we have replaced it with a `style` object or `processTextStyle` spread).
+    // When passing the style by identity (Unistyles routing) it is retained here, untouched.
+    if (!passStyleByIdentity && styleAttribute && attribute === styleAttribute) continue;
 
     // Skip the props we routed through `processAccessibilityProps`
     if (shouldNormalize && isNormalizedProperty(attribute)) continue;

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -23,8 +23,7 @@ import {
   extractSelectableAndUpdateStyle,
   tryBuildStaticTextStyle,
   ancestorBailoutChecks,
-  classifyStyleOrigin,
-  StyleOrigin,
+  createStyleOriginResolver,
 } from '../../utils/common';
 import { ACCESSIBILITY_PROPERTIES, RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_TEXT_MODULE } from '../../utils/constants';
 
@@ -93,11 +92,7 @@ export const textOptimizer: Optimizer = (path, logger, options, platform, unisty
 
   // In Unistyles mode, classify the direct `style` origin (lazily, once). A `style` carried by a spread
   // is already guarded (`style` ∈ TEXT_SPREAD_GUARD_KEYS), so only the direct attribute is classified.
-  let styleOrigin: StyleOrigin | undefined;
-  const getStyleOrigin = (): StyleOrigin => {
-    if (!unistylesEnabled) return 'plain';
-    return (styleOrigin ??= classifyStyleOrigin(path, extractStyleAttribute(path.node.attributes).styleExpr));
-  };
+  const getStyleOrigin = createStyleOriginResolver(path, unistylesEnabled);
 
   const overridableChecks: BailoutCheck[] = [
     {

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-imported-style-bails/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-imported-style-bails/code.js
@@ -1,0 +1,3 @@
+import { View } from 'react-native';
+import { styles } from './styles';
+<View style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-imported-style-bails/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-imported-style-bails/output.js
@@ -1,0 +1,3 @@
+import { View } from 'react-native';
+import { styles } from './styles';
+<View style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-no-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-no-style/code.js
@@ -1,0 +1,2 @@
+import { View } from 'react-native';
+<View />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-no-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-no-style/output.js
@@ -1,0 +1,3 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View } from 'react-native';
+<_NativeView />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-plain-rn-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-plain-rn-style/code.js
@@ -1,0 +1,3 @@
+import { View, StyleSheet } from 'react-native';
+const styles = StyleSheet.create({ box: { flex: 1 } });
+<View style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-plain-rn-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-plain-rn-style/output.js
@@ -1,0 +1,8 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View, StyleSheet } from 'react-native';
+const styles = StyleSheet.create({
+  box: {
+    flex: 1,
+  },
+});
+<_NativeView style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style-in-resolvable-spread-bails/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style-in-resolvable-spread-bails/code.js
@@ -1,0 +1,5 @@
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ box: { flex: 1 } });
+const extra = { style: styles.box };
+<View {...extra} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style-in-resolvable-spread-bails/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style-in-resolvable-spread-bails/output.js
@@ -1,0 +1,11 @@
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  box: {
+    flex: 1,
+  },
+});
+const extra = {
+  style: styles.box,
+};
+<View {...extra} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style/code.js
@@ -1,0 +1,4 @@
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({ box: { flex: 1 } });
+<View style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-style/output.js
@@ -1,0 +1,9 @@
+import _UnistylesNativeView from 'react-native-unistyles/components/native/NativeView';
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+const styles = StyleSheet.create({
+  box: {
+    flex: 1,
+  },
+});
+<_UnistylesNativeView style={styles.box} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/code.js
@@ -1,0 +1,2 @@
+import { View } from 'react-native';
+<View style={props.style} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures-unistyles/unistyles-unknown-style-bails/output.js
@@ -1,0 +1,2 @@
+import { View } from 'react-native';
+<View style={props.style} />;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
@@ -31,3 +31,13 @@ pluginTester({
     },
   ],
 });
+
+pluginTester({
+  plugin: generateTestPlugin(viewOptimizer, { unistyles: true }),
+  title: 'view unistyles',
+  fixtures: path.resolve(import.meta.dirname, 'fixtures-unistyles'),
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+});

--- a/packages/react-native-boost/src/plugin/optimizers/view/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/index.ts
@@ -14,8 +14,9 @@ import {
   replaceWithNativeComponent,
   ancestorBailoutChecks,
   createStyleOriginResolver,
+  UNISTYLES_VIEW_HOST,
 } from '../../utils/common';
-import { RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_VIEW_MODULE } from '../../utils/constants';
+import { RUNTIME_MODULE_NAME } from '../../utils/constants';
 
 /**
  * Props the `View` wrapper destructures and transforms before handing off to its native host. The
@@ -124,15 +125,8 @@ export const viewOptimizer: Optimizer = (path, logger, options, _platform, unist
   // A Unistyles-styled View routes to Unistyles' lean host (a registering wrapper around `RCTView`) so
   // its shadow-tree registration survives; the `style` already passes through verbatim. Everything else
   // optimizes to Boost's own raw host as usual.
-  if (getStyleOrigin() === 'unistyles') {
-    replaceWithNativeComponent(path, parent, file, 'NativeView', {
-      moduleName: UNISTYLES_NATIVE_VIEW_MODULE,
-      importType: 'default',
-      nameHint: 'UnistylesNativeView',
-    });
-  } else {
-    replaceWithNativeComponent(path, parent, file, 'NativeView');
-  }
+  const viewHost = getStyleOrigin() === 'unistyles' ? UNISTYLES_VIEW_HOST : undefined;
+  replaceWithNativeComponent(path, parent, file, 'NativeView', viewHost);
 };
 
 /**

--- a/packages/react-native-boost/src/plugin/optimizers/view/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/index.ts
@@ -13,9 +13,7 @@ import {
   isReactNativeImport,
   replaceWithNativeComponent,
   ancestorBailoutChecks,
-  extractStyleAttribute,
-  classifyStyleOrigin,
-  StyleOrigin,
+  createStyleOriginResolver,
 } from '../../utils/common';
 import { RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_VIEW_MODULE } from '../../utils/constants';
 
@@ -46,6 +44,11 @@ const VIEW_SPREAD_GUARD_KEYS = new Set([
   'tabIndex',
 ]);
 
+// In Unistyles mode a `style` arriving through a resolvable spread must also bail (it could be a
+// Unistyles style), so the guard set additionally includes `style`. Precomputed to avoid rebuilding it
+// per element.
+const VIEW_SPREAD_GUARD_KEYS_UNISTYLES = new Set([...VIEW_SPREAD_GUARD_KEYS, 'style']);
+
 // ARIA siblings that trigger aggregation. Their presence routes the whole matching group (including a
 // passed `accessibilityState`/`accessibilityValue`) through the runtime helper, because the wrapper
 // merges them (`ariaX ?? source?.x`) and a partial literal translation could not reproduce that.
@@ -59,15 +62,11 @@ export const viewOptimizer: Optimizer = (path, logger, options, _platform, unist
   const forced = isForcedLine(path);
 
   // In Unistyles mode, classify the direct `style` origin (lazily, once). A `style` carried by a
-  // resolvable spread is guarded too (`style` is added to the spread keys below); an unresolvable spread
+  // resolvable spread is guarded too (`style` is in the Unistyles spread keys); an unresolvable spread
   // already bails. See {@link classifyStyleOrigin}.
-  let styleOrigin: StyleOrigin | undefined;
-  const getStyleOrigin = (): StyleOrigin => {
-    if (!unistylesEnabled) return 'plain';
-    return (styleOrigin ??= classifyStyleOrigin(path, extractStyleAttribute(path.node.attributes).styleExpr));
-  };
+  const getStyleOrigin = createStyleOriginResolver(path, unistylesEnabled);
 
-  const spreadGuardKeys = unistylesEnabled ? new Set([...VIEW_SPREAD_GUARD_KEYS, 'style']) : VIEW_SPREAD_GUARD_KEYS;
+  const spreadGuardKeys = unistylesEnabled ? VIEW_SPREAD_GUARD_KEYS_UNISTYLES : VIEW_SPREAD_GUARD_KEYS;
 
   const overridableChecks: BailoutCheck[] = [
     {

--- a/packages/react-native-boost/src/plugin/optimizers/view/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/index.ts
@@ -13,8 +13,11 @@ import {
   isReactNativeImport,
   replaceWithNativeComponent,
   ancestorBailoutChecks,
+  extractStyleAttribute,
+  classifyStyleOrigin,
+  StyleOrigin,
 } from '../../utils/common';
-import { RUNTIME_MODULE_NAME } from '../../utils/constants';
+import { RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_VIEW_MODULE } from '../../utils/constants';
 
 /**
  * Props the `View` wrapper destructures and transforms before handing off to its native host. The
@@ -49,16 +52,31 @@ const VIEW_SPREAD_GUARD_KEYS = new Set([
 const ARIA_STATE_PROPERTIES = new Set(['aria-busy', 'aria-checked', 'aria-disabled', 'aria-expanded', 'aria-selected']);
 const ARIA_VALUE_PROPERTIES = new Set(['aria-valuemax', 'aria-valuemin', 'aria-valuenow', 'aria-valuetext']);
 
-export const viewOptimizer: Optimizer = (path, logger, options) => {
+export const viewOptimizer: Optimizer = (path, logger, options, _platform, unistylesEnabled) => {
   if (!isValidJSXComponent(path, 'View')) return;
   if (!isReactNativeImport(path, 'View')) return;
 
   const forced = isForcedLine(path);
 
+  // In Unistyles mode, classify the direct `style` origin (lazily, once). A `style` carried by a
+  // resolvable spread is guarded too (`style` is added to the spread keys below); an unresolvable spread
+  // already bails. See {@link classifyStyleOrigin}.
+  let styleOrigin: StyleOrigin | undefined;
+  const getStyleOrigin = (): StyleOrigin => {
+    if (!unistylesEnabled) return 'plain';
+    return (styleOrigin ??= classifyStyleOrigin(path, extractStyleAttribute(path.node.attributes).styleExpr));
+  };
+
+  const spreadGuardKeys = unistylesEnabled ? new Set([...VIEW_SPREAD_GUARD_KEYS, 'style']) : VIEW_SPREAD_GUARD_KEYS;
+
   const overridableChecks: BailoutCheck[] = [
     {
       reason: 'has a spread that may carry a translated prop',
-      shouldBail: () => hasBlacklistedPropertyInSpread(path, VIEW_SPREAD_GUARD_KEYS),
+      shouldBail: () => hasBlacklistedPropertyInSpread(path, spreadGuardKeys),
+    },
+    {
+      reason: 'has an unresolved style source that may be a Unistyles style',
+      shouldBail: () => getStyleOrigin() === 'unknown',
     },
     {
       reason: 'has both a dynamic `id` and a `nativeID` (ambiguous precedence)',
@@ -104,7 +122,18 @@ export const viewOptimizer: Optimizer = (path, logger, options) => {
 
   processViewProps(path, file);
 
-  replaceWithNativeComponent(path, parent, file, 'NativeView');
+  // A Unistyles-styled View routes to Unistyles' lean host (a registering wrapper around `RCTView`) so
+  // its shadow-tree registration survives; the `style` already passes through verbatim. Everything else
+  // optimizes to Boost's own raw host as usual.
+  if (getStyleOrigin() === 'unistyles') {
+    replaceWithNativeComponent(path, parent, file, 'NativeView', {
+      moduleName: UNISTYLES_NATIVE_VIEW_MODULE,
+      importType: 'default',
+      nameHint: 'UnistylesNativeView',
+    });
+  } else {
+    replaceWithNativeComponent(path, parent, file, 'NativeView');
+  }
 };
 
 /**

--- a/packages/react-native-boost/src/plugin/types/index.ts
+++ b/packages/react-native-boost/src/plugin/types/index.ts
@@ -44,6 +44,23 @@ export interface PluginOptions {
    */
   optimizations?: PluginOptimizationOptions;
   /**
+   * Enables "Unistyles mode": keep `react-native-unistyles` reactivity working on optimized elements.
+   *
+   * When enabled, a `Text`/`View` whose `style` resolves to a Unistyles `StyleSheet.create` style is
+   * rewritten to Unistyles' own lean host (so its shadow-tree registration survives and theme/breakpoint/
+   * variant updates keep working) instead of Boost's raw host; a `Text`/`View` with an unresolvable
+   * direct `style` (e.g. `style={props.style}`, a function call) is left untouched, because it could be a
+   * Unistyles style arriving from elsewhere; plain/RN styles still optimize to Boost's host as usual.
+   *
+   * Style origin is resolved within a single file only (cross-file stylesheets count as unresolvable).
+   *
+   * When omitted, the plugin auto-detects whether `react-native-unistyles` is installed and enables this
+   * if so (and logs a one-time hint to set the flag explicitly). Set to `false` to force it off even when
+   * Unistyles is installed.
+   * @default undefined (auto-detected)
+   */
+  unistyles?: boolean;
+  /**
    * Opt-in flag that allows View optimization when ancestor components cannot be statically resolved.
    *
    * This increases optimization coverage, but may introduce behavioral differences
@@ -93,7 +110,13 @@ export type Optimizer = (
   logger: PluginLogger,
   options?: PluginOptions,
   /** Target platform from Babel's caller (e.g. Metro sets `'ios'`/`'android'`). Lets optimizers resolve platform-specific defaults at build time. */
-  platform?: string
+  platform?: string,
+  /**
+   * Whether "Unistyles mode" is active for this build (resolved once at plugin init from the `unistyles`
+   * option + install auto-detection). When `true`, optimizers classify each element's `style` origin and
+   * route Unistyles styles to Unistyles' lean host instead of Boost's raw host.
+   */
+  unistylesEnabled?: boolean
 ) => void;
 
 export type HubFile = t.File & {

--- a/packages/react-native-boost/src/plugin/utils/common/base.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/base.ts
@@ -2,6 +2,7 @@ import { NodePath, types as t } from '@babel/core';
 import { addDefault, addNamed } from '@babel/helper-module-imports';
 import { FileImportOptions, HubFile } from '../../types';
 import { RUNTIME_MODULE_NAME } from '../constants';
+import { markOptimizedHost } from './optimized-host';
 
 /**
  * Adds a hint to the file object to ensure that a specific import is added only once and cached on the file object.
@@ -78,6 +79,10 @@ export const replaceWithNativeComponent = (
 
   // Get the current name of the component, which may be aliased (i.e. Text -> RNText)
   const currentName = (path.node.name as t.JSXIdentifier).name;
+
+  // Record what this element was optimized into so the ancestor walk can classify it once it becomes a
+  // descendant's ancestor (the injected import is not yet resolvable via scope this traversal).
+  markOptimizedHost(path.node, nativeComponentName === 'NativeText' ? 'text' : 'view');
 
   // Replace the component with its native counterpart
   const jsxName = path.node.name as t.JSXIdentifier;

--- a/packages/react-native-boost/src/plugin/utils/common/base.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/base.ts
@@ -35,30 +35,45 @@ export function addFileImportHint({
 }
 
 /**
+ * Where to import an optimized element's replacement host from. Defaults to Boost's own runtime
+ * (`react-native-boost/runtime`, named import). Unistyles mode overrides this to point at Unistyles'
+ * lean host components, which are version-matched registering wrappers (e.g. `NativeView` is a default
+ * export). A distinct `nameHint` keeps the import cache from colliding when a file uses both a Boost
+ * host and a Unistyles host.
+ */
+export interface NativeComponentSource {
+  moduleName?: string;
+  importName?: string;
+  importType?: 'named' | 'default';
+  nameHint?: string;
+}
+
+/**
  * Replaces a component with its native counterpart.
  * This function handles both the opening and closing tags.
  *
  * @param path - The path to the JSXOpeningElement.
  * @param parent - The parent JSX element.
  * @param file - The Babel file object.
- * @param nativeComponentName - The name of the native component to import.
- * @param moduleName - The module to import the native component from.
+ * @param nativeComponentName - The local-name basis for the injected import (and the default import name).
+ * @param source - Optional override for where to import the host from (see {@link NativeComponentSource}).
  * @returns The identifier for the imported native component.
  */
 export const replaceWithNativeComponent = (
   path: NodePath<t.JSXOpeningElement>,
   parent: t.JSXElement,
   file: HubFile,
-  nativeComponentName: string
+  nativeComponentName: string,
+  source: NativeComponentSource = {}
 ): t.Identifier => {
   // Add native component import (cached on file) to prevent duplicate imports
   const nativeIdentifier = addFileImportHint({
     file,
-    nameHint: nativeComponentName,
+    nameHint: source.nameHint ?? nativeComponentName,
     path,
-    importName: nativeComponentName,
-    moduleName: RUNTIME_MODULE_NAME,
-    importType: 'named',
+    importName: source.importName ?? nativeComponentName,
+    moduleName: source.moduleName ?? RUNTIME_MODULE_NAME,
+    importType: source.importType ?? 'named',
   });
 
   // Get the current name of the component, which may be aliased (i.e. Text -> RNText)

--- a/packages/react-native-boost/src/plugin/utils/common/base.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/base.ts
@@ -1,8 +1,8 @@
 import { NodePath, types as t } from '@babel/core';
 import { addDefault, addNamed } from '@babel/helper-module-imports';
 import { FileImportOptions, HubFile } from '../../types';
-import { RUNTIME_MODULE_NAME } from '../constants';
-import { markOptimizedHost } from './optimized-host';
+import { RUNTIME_MODULE_NAME, UNISTYLES_NATIVE_TEXT_MODULE, UNISTYLES_NATIVE_VIEW_MODULE } from '../constants';
+import { markOptimizedHost, OptimizedHostKind } from './optimized-host';
 
 /**
  * Adds a hint to the file object to ensure that a specific import is added only once and cached on the file object.
@@ -49,6 +49,31 @@ export interface NativeComponentSource {
   nameHint?: string;
 }
 
+/** The native hosts Boost rewrites elements into; the local-name basis for each injected import. */
+type NativeComponentName = 'NativeText' | 'NativeView';
+
+/** Which context each optimized host establishes for the ancestor walk. Total over every host name. */
+const HOST_KIND_BY_NAME: Record<NativeComponentName, OptimizedHostKind> = {
+  NativeText: 'text',
+  NativeView: 'view',
+};
+
+/**
+ * Import sources for Unistyles' own lean hosts, passed as the `source` override when an element's `style`
+ * resolves to a Unistyles style.
+ */
+export const UNISTYLES_TEXT_HOST: NativeComponentSource = {
+  moduleName: UNISTYLES_NATIVE_TEXT_MODULE,
+  importName: 'NativeText',
+  nameHint: 'UnistylesNativeText',
+};
+
+export const UNISTYLES_VIEW_HOST: NativeComponentSource = {
+  moduleName: UNISTYLES_NATIVE_VIEW_MODULE,
+  importType: 'default',
+  nameHint: 'UnistylesNativeView',
+};
+
 /**
  * Replaces a component with its native counterpart.
  * This function handles both the opening and closing tags.
@@ -64,7 +89,7 @@ export const replaceWithNativeComponent = (
   path: NodePath<t.JSXOpeningElement>,
   parent: t.JSXElement,
   file: HubFile,
-  nativeComponentName: string,
+  nativeComponentName: NativeComponentName,
   source: NativeComponentSource = {}
 ): t.Identifier => {
   // Add native component import (cached on file) to prevent duplicate imports
@@ -82,7 +107,7 @@ export const replaceWithNativeComponent = (
 
   // Record what this element was optimized into so the ancestor walk can classify it once it becomes a
   // descendant's ancestor (the injected import is not yet resolvable via scope this traversal).
-  markOptimizedHost(path.node, nativeComponentName === 'NativeText' ? 'text' : 'view');
+  markOptimizedHost(path.node, HOST_KIND_BY_NAME[nativeComponentName]);
 
   // Replace the component with its native counterpart
   const jsxName = path.node.name as t.JSXIdentifier;

--- a/packages/react-native-boost/src/plugin/utils/common/index.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/index.ts
@@ -1,3 +1,4 @@
 export * from './validation';
 export * from './attributes';
 export * from './base';
+export * from './optimized-host';

--- a/packages/react-native-boost/src/plugin/utils/common/optimized-host.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/optimized-host.ts
@@ -1,0 +1,19 @@
+import { types as t } from '@babel/core';
+
+export type OptimizedHostKind = 'text' | 'view';
+
+/**
+ * Records, per `JSXOpeningElement` node, which kind of host Boost rewrote it into. The ancestor walk
+ * reads this to classify an already-optimized ancestor by what it renders, without depending on the
+ * just-injected import being resolvable via scope (a fresh `addNamed` import is not yet crawled into
+ * scope during the same traversal, so `getBinding` returns `undefined` for it). A `WeakMap` keyed on the
+ * node avoids mutating the AST and is collected with the file's nodes after the transform.
+ */
+const optimizedHosts = new WeakMap<t.JSXOpeningElement, OptimizedHostKind>();
+
+export const markOptimizedHost = (openingElement: t.JSXOpeningElement, kind: OptimizedHostKind): void => {
+  optimizedHosts.set(openingElement, kind);
+};
+
+export const getOptimizedHostKind = (openingElement: t.JSXOpeningElement): OptimizedHostKind | undefined =>
+  optimizedHosts.get(openingElement);

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -11,6 +11,7 @@ import {
   RUNTIME_MODULE_NAME,
 } from '../constants';
 import { getOptimizedHostKind } from './optimized-host';
+import { extractStyleAttribute } from './attributes';
 
 /**
  * Checks if the file is in the list of ignored files.
@@ -756,6 +757,27 @@ function getStaticExpressionTruthiness(expression: t.Expression | t.JSXEmptyExpr
 
 export type StyleOrigin = 'unistyles' | 'plain' | 'unknown';
 
+// Bounds the alias/array/wrapper recursion in `classifyStyleExpression`, which would otherwise loop
+// forever on a pathological const cycle (`const a = b; const b = a`). Past this depth the source is
+// undecidable, so it classifies as `'unknown'` (a safe bail).
+const MAX_STYLE_RESOLUTION_DEPTH = 64;
+
+/**
+ * Builds a lazily-memoized resolver for an element's direct `style` origin, shared by the `Text` and
+ * `View` optimizers. Outside Unistyles mode it is a constant `'plain'` (no work). Inside, it classifies
+ * on first call and caches — kept lazy so an element that bails on a cheaper check never pays the
+ * classification cost.
+ */
+export const createStyleOriginResolver = (
+  path: NodePath<t.JSXOpeningElement>,
+  unistylesEnabled: boolean | undefined
+): (() => StyleOrigin) => {
+  if (!unistylesEnabled) return () => 'plain';
+
+  let styleOrigin: StyleOrigin | undefined;
+  return () => (styleOrigin ??= classifyStyleOrigin(path, extractStyleAttribute(path.node.attributes).styleExpr));
+};
+
 /**
  * Classifies where a JSX element's direct `style` value comes from, used to route an element in
  * "Unistyles mode". Resolution is **same-file only** — anything that would require following an import,
@@ -776,7 +798,20 @@ export const classifyStyleOrigin = (
   return classifyStyleExpression(path, styleExpr);
 };
 
-function classifyStyleExpression(path: NodePath<t.JSXOpeningElement>, expr: t.Expression): StyleOrigin {
+function classifyStyleExpression(path: NodePath<t.JSXOpeningElement>, expr: t.Expression, depth = 0): StyleOrigin {
+  if (depth > MAX_STYLE_RESOLUTION_DEPTH) return 'unknown';
+
+  // TS-only and parenthesized wrappers do not change the runtime style value, so `styles.foo as TextStyle`,
+  // `styles.foo!`, `styles.foo satisfies …`, and `(styles.foo)` classify exactly like `styles.foo`.
+  if (
+    t.isTSAsExpression(expr) ||
+    t.isTSSatisfiesExpression(expr) ||
+    t.isTSNonNullExpression(expr) ||
+    t.isParenthesizedExpression(expr)
+  ) {
+    return classifyStyleExpression(path, expr.expression, depth + 1);
+  }
+
   // An inline object literal could only carry Unistyles state by spreading one in — which strips that
   // state anyway and is already broken under Unistyles — so a spread makes it unprovable; a plain
   // literal is provably non-Unistyles.
@@ -789,7 +824,7 @@ function classifyStyleExpression(path: NodePath<t.JSXOpeningElement>, expr: t.Ex
     for (const element of expr.elements) {
       if (element == null) continue; // hole → flattens away
       if (t.isSpreadElement(element)) return 'unknown';
-      const elementOrigin = classifyStyleExpression(path, element);
+      const elementOrigin = classifyStyleExpression(path, element, depth + 1);
       // A single Unistyles element makes the whole array Unistyles-managed: routing the array by
       // identity to the lean host preserves that element's registration regardless of its siblings.
       if (elementOrigin === 'unistyles') return 'unistyles';
@@ -798,18 +833,18 @@ function classifyStyleExpression(path: NodePath<t.JSXOpeningElement>, expr: t.Ex
     return result;
   }
 
-  // `styles.foo` / `styles['foo']` — classify by the `styles` container's `StyleSheet.create` origin.
-  if (t.isMemberExpression(expr)) {
+  // `styles.foo` / `styles['foo']` / `styles?.foo` — classify by the `styles` container's origin.
+  if (t.isMemberExpression(expr) || t.isOptionalMemberExpression(expr)) {
     if (!t.isIdentifier(expr.object)) return 'unknown';
     return classifyStyleContainerBinding(path.scope.getBinding(expr.object.name));
   }
 
-  // A local `const x = <style expr>` alias — follow it once.
+  // A local `const x = <style expr>` alias — follow it.
   if (t.isIdentifier(expr)) {
     const binding = path.scope.getBinding(expr.name);
     if (!binding || !binding.constant || !binding.path.isVariableDeclarator()) return 'unknown';
     const init = binding.path.node.init;
-    if (init && t.isExpression(init)) return classifyStyleExpression(path, init);
+    if (init && t.isExpression(init)) return classifyStyleExpression(path, init, depth + 1);
     return 'unknown';
   }
 

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -4,6 +4,7 @@ import { HubFile } from '../../types';
 import { minimatch } from 'minimatch';
 import nodePath from 'node:path';
 import PluginError from '../plugin-error';
+import { UNISTYLES_MODULE_NAME } from '../constants';
 
 /**
  * Checks if the file is in the list of ignored files.
@@ -711,4 +712,102 @@ function getStaticExpressionTruthiness(expression: t.Expression | t.JSXEmptyExpr
   }
 
   return undefined;
+}
+
+export type StyleOrigin = 'unistyles' | 'plain' | 'unknown';
+
+/**
+ * Classifies where a JSX element's direct `style` value comes from, used to route an element in
+ * "Unistyles mode". Resolution is **same-file only** — anything that would require following an import,
+ * or that cannot be proven, is `'unknown'`.
+ *
+ * - `'plain'` — no `style`, an object literal, or a `StyleSheet.create(...)` imported from `react-native`:
+ *   provably not a Unistyles style, so it is safe to optimize to Boost's own host as usual.
+ * - `'unistyles'` — a `StyleSheet.create(...)` imported from `react-native-unistyles`, used directly or as
+ *   any element of a style array: must be routed to Unistyles' lean host so its registration survives.
+ * - `'unknown'` — a prop/param/call/conditional, an imported stylesheet, or any unresolvable reference:
+ *   undecidable within one file, so it could be a Unistyles style arriving from elsewhere.
+ */
+export const classifyStyleOrigin = (
+  path: NodePath<t.JSXOpeningElement>,
+  styleExpr: t.Expression | undefined
+): StyleOrigin => {
+  if (!styleExpr) return 'plain';
+  return classifyStyleExpression(path, styleExpr);
+};
+
+function classifyStyleExpression(path: NodePath<t.JSXOpeningElement>, expr: t.Expression): StyleOrigin {
+  // An inline object literal could only carry Unistyles state by spreading one in — which strips that
+  // state anyway and is already broken under Unistyles — so a spread makes it unprovable; a plain
+  // literal is provably non-Unistyles.
+  if (t.isObjectExpression(expr)) {
+    return expr.properties.some((property) => t.isSpreadElement(property)) ? 'unknown' : 'plain';
+  }
+
+  if (t.isArrayExpression(expr)) {
+    let result: StyleOrigin = 'plain';
+    for (const element of expr.elements) {
+      if (element == null) continue; // hole → flattens away
+      if (t.isSpreadElement(element)) return 'unknown';
+      const elementOrigin = classifyStyleExpression(path, element);
+      // A single Unistyles element makes the whole array Unistyles-managed: routing the array by
+      // identity to the lean host preserves that element's registration regardless of its siblings.
+      if (elementOrigin === 'unistyles') return 'unistyles';
+      if (elementOrigin === 'unknown') result = 'unknown';
+    }
+    return result;
+  }
+
+  // `styles.foo` / `styles['foo']` — classify by the `styles` container's `StyleSheet.create` origin.
+  if (t.isMemberExpression(expr)) {
+    if (!t.isIdentifier(expr.object)) return 'unknown';
+    return classifyStyleContainerBinding(path.scope.getBinding(expr.object.name));
+  }
+
+  // A local `const x = <style expr>` alias — follow it once.
+  if (t.isIdentifier(expr)) {
+    const binding = path.scope.getBinding(expr.name);
+    if (!binding || !binding.constant || !binding.path.isVariableDeclarator()) return 'unknown';
+    const init = binding.path.node.init;
+    if (init && t.isExpression(init)) return classifyStyleExpression(path, init);
+    return 'unknown';
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Classifies the binding behind the `styles` in `styles.foo`: it must be a same-file, non-reassigned
+ * `const styles = <StyleSheet>.create(...)` whose `StyleSheet` import source identifies the engine.
+ */
+function classifyStyleContainerBinding(binding: ScopeBinding | undefined): StyleOrigin {
+  if (!binding || !binding.constant) return 'unknown';
+  if (binding.kind === 'module') return 'unknown'; // imported stylesheet → cross-file, out of scope
+  if (!binding.path.isVariableDeclarator()) return 'unknown';
+
+  const init = binding.path.node.init;
+  if (!init || !t.isCallExpression(init)) return 'unknown';
+
+  return classifyStyleSheetCreateCallee(binding.path.scope, init.callee);
+}
+
+/**
+ * Classifies a `StyleSheet.create` callee by the import source of its `StyleSheet` object:
+ * `react-native-unistyles` → `'unistyles'`, `react-native` → `'plain'`, anything else → `'unknown'`.
+ */
+function classifyStyleSheetCreateCallee(
+  scope: NodePath<t.Node>['scope'],
+  callee: t.Expression | t.V8IntrinsicIdentifier
+): StyleOrigin {
+  if (!t.isMemberExpression(callee) || callee.computed) return 'unknown';
+  if (!t.isIdentifier(callee.property, { name: 'create' })) return 'unknown';
+  if (!t.isIdentifier(callee.object)) return 'unknown';
+
+  const binding = scope.getBinding(callee.object.name);
+  if (!binding || binding.kind !== 'module' || !t.isImportDeclaration(binding.path.parent)) return 'unknown';
+
+  const source = binding.path.parent.source.value;
+  if (source === UNISTYLES_MODULE_NAME) return 'unistyles';
+  if (source === 'react-native') return 'plain';
+  return 'unknown';
 }

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -4,7 +4,13 @@ import { HubFile } from '../../types';
 import { minimatch } from 'minimatch';
 import nodePath from 'node:path';
 import PluginError from '../plugin-error';
-import { UNISTYLES_MODULE_NAME } from '../constants';
+import {
+  UNISTYLES_MODULE_NAME,
+  UNISTYLES_NATIVE_TEXT_MODULE,
+  UNISTYLES_NATIVE_VIEW_MODULE,
+  RUNTIME_MODULE_NAME,
+} from '../constants';
+import { getOptimizedHostKind } from './optimized-host';
 
 /**
  * Checks if the file is in the list of ignored files.
@@ -243,6 +249,12 @@ function classifyJSXElementAsAncestor(
   path: NodePath<t.JSXElement>,
   context: AncestorAnalysisContext
 ): AncestorClassification {
+  // An ancestor Boost already rewrote earlier in this same traversal: classify it by the host it
+  // became (Text → inline-text context, View → normal context). This is checked before the import-based
+  // paths because the freshly-injected host import is not yet resolvable via scope.
+  const optimizedHostKind = getOptimizedHostKind(path.node.openingElement);
+  if (optimizedHostKind) return optimizedHostKind === 'text' ? 'text' : 'safe';
+
   const openingElementName = path.node.openingElement.name;
 
   if (t.isJSXIdentifier(openingElementName)) {
@@ -323,12 +335,40 @@ function classifyModuleBindingAsAncestor(binding: ScopeBinding): AncestorClassif
     return 'unknown';
   }
 
+  // An ancestor Boost itself already rewrote (its own runtime host, or a Unistyles lean host in
+  // Unistyles mode) is a *known* host: a View establishes a normal context ('safe'), a Text an
+  // inline-text context ('text'). Without this, a descendant of an optimized element would read its
+  // rewritten ancestor as 'unknown' and bail — so only the outermost element of any subtree could ever
+  // optimize. Classifying by what the host renders lets optimization cascade down the tree.
+  const optimizedHost = classifyOptimizedHostAncestor(source, binding);
+  if (optimizedHost) return optimizedHost;
+
   if (source === 'react' && t.isImportSpecifier(binding.path.node)) {
     const importedName = getImportSpecifierImportedName(binding.path.node);
     if (importedName === 'Fragment') return 'safe';
   }
 
   return 'unknown';
+}
+
+/**
+ * Classifies an ancestor that is one of the optimized hosts Boost emits — its own runtime
+ * `NativeText`/`NativeView`, or (in Unistyles mode) Unistyles' lean `NativeText`/`NativeView`. Returns
+ * `'text'` for a Text host, `'safe'` for a View host, or `undefined` when the source is not a known
+ * optimized host. The Unistyles lean hosts are keyed purely by their (component-specific) import source;
+ * Boost's own runtime exports both hosts from one module, so its imported name is checked.
+ */
+function classifyOptimizedHostAncestor(source: string, binding: ScopeBinding): AncestorClassification | undefined {
+  if (source === UNISTYLES_NATIVE_TEXT_MODULE) return 'text';
+  if (source === UNISTYLES_NATIVE_VIEW_MODULE) return 'safe';
+
+  if (source === RUNTIME_MODULE_NAME && t.isImportSpecifier(binding.path.node)) {
+    const importedName = getImportSpecifierImportedName(binding.path.node);
+    if (importedName === 'NativeText') return 'text';
+    if (importedName === 'NativeView') return 'safe';
+  }
+
+  return undefined;
 }
 
 function classifyLocalBindingAsAncestor(

--- a/packages/react-native-boost/src/plugin/utils/constants.ts
+++ b/packages/react-native-boost/src/plugin/utils/constants.ts
@@ -1,6 +1,22 @@
 export const RUNTIME_MODULE_NAME = 'react-native-boost/runtime';
 
 /**
+ * The npm package name of Unistyles, used both for the install probe (auto-detecting "Unistyles mode")
+ * and for classifying a `StyleSheet.create` call's origin.
+ */
+export const UNISTYLES_MODULE_NAME = 'react-native-unistyles';
+
+/**
+ * Unistyles' own "lean" host components — `createUnistylesElement(RCTText/RCTView)`. Routing a
+ * Unistyles-styled element to these keeps Unistyles' shadow-tree registration (so reactivity survives)
+ * while still skipping React Native's `Text`/`View` wrapper, which is the optimization Boost provides.
+ * `NativeText` is a named export; `NativeView` is the module's default export (it mirrors RN's default
+ * `View` export). These subpaths are part of Unistyles' `./components/native/*` exports map.
+ */
+export const UNISTYLES_NATIVE_TEXT_MODULE = `${UNISTYLES_MODULE_NAME}/components/native/NativeText`;
+export const UNISTYLES_NATIVE_VIEW_MODULE = `${UNISTYLES_MODULE_NAME}/components/native/NativeView`;
+
+/**
  * The set of accessibility properties that need to be normalized.
  */
 export const ACCESSIBILITY_PROPERTIES = new Set([

--- a/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
+++ b/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
@@ -1,6 +1,8 @@
 import { declare } from '@babel/helper-plugin-utils';
 import { Optimizer, PluginOptions } from '../types';
 import { createLogger } from './logger';
+import { textOptimizer } from '../optimizers/text';
+import { viewOptimizer } from '../optimizers/view';
 
 export const generateTestPlugin = (optimizer: Optimizer, options: PluginOptions = {}) => {
   const logger = createLogger({
@@ -18,6 +20,34 @@ export const generateTestPlugin = (optimizer: Optimizer, options: PluginOptions 
           // Mirror the real plugin's explicit-flag resolution for Unistyles mode (auto-detection is not
           // exercised in fixtures); a fixture opts in with `{ unistyles: true }`.
           optimizer(path, logger, options, undefined, options.unistyles === true);
+        },
+      },
+    };
+  });
+};
+
+/**
+ * Runs both optimizers per element, exactly as the real plugin does (`textOptimizer` then
+ * `viewOptimizer`). Needed for cases that depend on the two interacting — notably nested elements, where
+ * an outer `View` must be rewritten before an inner element classifies it as an ancestor.
+ */
+export const generateCombinedTestPlugin = (options: PluginOptions = {}) => {
+  const logger = createLogger({
+    verbose: false,
+    silent: true,
+  });
+
+  return declare((api) => {
+    api.assertVersion(7);
+
+    const unistylesEnabled = options.unistyles === true;
+
+    return {
+      name: 'react-native-boost',
+      visitor: {
+        JSXOpeningElement(path) {
+          textOptimizer(path, logger, options, undefined, unistylesEnabled);
+          viewOptimizer(path, logger, options, undefined, unistylesEnabled);
         },
       },
     };

--- a/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
+++ b/packages/react-native-boost/src/plugin/utils/generate-test-plugin.ts
@@ -15,7 +15,9 @@ export const generateTestPlugin = (optimizer: Optimizer, options: PluginOptions 
       name: 'react-native-boost',
       visitor: {
         JSXOpeningElement(path) {
-          optimizer(path, logger, options);
+          // Mirror the real plugin's explicit-flag resolution for Unistyles mode (auto-detection is not
+          // exercised in fixtures); a fixture opts in with `{ unistyles: true }`.
+          optimizer(path, logger, options, undefined, options.unistyles === true);
         },
       },
     };

--- a/packages/react-native-boost/src/plugin/utils/logger.ts
+++ b/packages/react-native-boost/src/plugin/utils/logger.ts
@@ -47,7 +47,7 @@ export const createLogger = ({ verbose, silent }: { verbose: boolean; silent: bo
 };
 
 function formatWarningContext(payload: WarningLogPayload): string {
-  const location = formatPathLocation(payload.path);
+  const location = payload.path ? formatPathLocation(payload.path) : '';
 
   if (payload.component && location.length > 0) {
     return `${payload.component} in ${location}`;

--- a/packages/react-native-boost/src/plugin/utils/unistyles.ts
+++ b/packages/react-native-boost/src/plugin/utils/unistyles.ts
@@ -29,14 +29,21 @@ export function isUnistylesInstalled(fromDirectory: string | undefined): boolean
 function readNearestPackageJson(fromDirectory: string): Record<string, unknown> | undefined {
   let directory = nodePath.resolve(fromDirectory);
 
-  // Walk up until the filesystem root, stopping at the first readable `package.json`.
+  // Walk up to the nearest directory that has a `package.json`. An absent manifest means "keep looking";
+  // a present-but-unreadable/malformed one stops the walk and declines to auto-enable, rather than
+  // misattributing a parent workspace's dependencies to this project.
   for (;;) {
-    try {
-      return JSON.parse(fs.readFileSync(nodePath.join(directory, 'package.json'), 'utf8'));
-    } catch {
-      const parent = nodePath.dirname(directory);
-      if (parent === directory) return undefined;
-      directory = parent;
+    const manifestPath = nodePath.join(directory, 'package.json');
+    if (fs.existsSync(manifestPath)) {
+      try {
+        return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      } catch {
+        return undefined;
+      }
     }
+
+    const parent = nodePath.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
   }
 }

--- a/packages/react-native-boost/src/plugin/utils/unistyles.ts
+++ b/packages/react-native-boost/src/plugin/utils/unistyles.ts
@@ -1,0 +1,23 @@
+import { createRequire } from 'node:module';
+import nodePath from 'node:path';
+import { UNISTYLES_MODULE_NAME } from './constants';
+
+/**
+ * Whether `react-native-unistyles` is resolvable from the given directory (Babel's config dirname,
+ * falling back to the process working directory). Used to auto-enable "Unistyles mode".
+ *
+ * An installed package does not prove that Unistyles' own Babel plugin is active in the project, so a
+ * positive result only auto-enables the mode and emits a one-time hint to set the `unistyles` flag
+ * explicitly. `createRequire` is used so the probe works in both the CJS and ESM plugin builds; the
+ * anchor path only needs to seed the `node_modules` lookup, it does not need to exist.
+ */
+export function isUnistylesInstalled(fromDirectory: string | undefined): boolean {
+  const base = fromDirectory ?? process.cwd();
+  try {
+    const require = createRequire(nodePath.join(base, 'package.json'));
+    require.resolve(`${UNISTYLES_MODULE_NAME}/package.json`);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/react-native-boost/src/plugin/utils/unistyles.ts
+++ b/packages/react-native-boost/src/plugin/utils/unistyles.ts
@@ -1,23 +1,42 @@
-import { createRequire } from 'node:module';
+import fs from 'node:fs';
 import nodePath from 'node:path';
 import { UNISTYLES_MODULE_NAME } from './constants';
 
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const;
+
 /**
- * Whether `react-native-unistyles` is resolvable from the given directory (Babel's config dirname,
- * falling back to the process working directory). Used to auto-enable "Unistyles mode".
+ * Whether the project being built declares `react-native-unistyles` as a dependency. Used to auto-enable
+ * "Unistyles mode".
  *
- * An installed package does not prove that Unistyles' own Babel plugin is active in the project, so a
- * positive result only auto-enables the mode and emits a one-time hint to set the `unistyles` flag
- * explicitly. `createRequire` is used so the probe works in both the CJS and ESM plugin builds; the
- * anchor path only needs to seed the `node_modules` lookup, it does not need to exist.
+ * Resolution walks up from Babel's config dirname (falling back to the process working directory) to the
+ * nearest `package.json` and checks its dependency fields. This is deliberately stricter than a
+ * `require.resolve` probe: in a monorepo (or with a hoisted/transitive copy) the package is often
+ * resolvable from a project that does not actually use it, which would wrongly enable the mode and its
+ * bailouts for unrelated packages. A declared dependency is the project's own signal that it uses
+ * Unistyles. The result still only auto-enables the mode and emits a one-time hint to set the `unistyles`
+ * flag explicitly, since a declared dependency does not prove Unistyles' own Babel plugin is active.
  */
 export function isUnistylesInstalled(fromDirectory: string | undefined): boolean {
-  const base = fromDirectory ?? process.cwd();
-  try {
-    const require = createRequire(nodePath.join(base, 'package.json'));
-    require.resolve(`${UNISTYLES_MODULE_NAME}/package.json`);
-    return true;
-  } catch {
-    return false;
+  const packageJson = readNearestPackageJson(fromDirectory ?? process.cwd());
+  if (!packageJson) return false;
+
+  return DEPENDENCY_FIELDS.some((field) => {
+    const dependencies = packageJson[field];
+    return typeof dependencies === 'object' && dependencies !== null && UNISTYLES_MODULE_NAME in dependencies;
+  });
+}
+
+function readNearestPackageJson(fromDirectory: string): Record<string, unknown> | undefined {
+  let directory = nodePath.resolve(fromDirectory);
+
+  // Walk up until the filesystem root, stopping at the first readable `package.json`.
+  for (;;) {
+    try {
+      return JSON.parse(fs.readFileSync(nodePath.join(directory, 'package.json'), 'utf8'));
+    } catch {
+      const parent = nodePath.dirname(directory);
+      if (parent === directory) return undefined;
+      directory = parent;
+    }
   }
 }

--- a/packages/react-native-boost/tsconfig.json
+++ b/packages/react-native-boost/tsconfig.json
@@ -2,5 +2,5 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {},
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "plugin", "fixtures", "scripts"]
+  "exclude": ["node_modules", "plugin", "fixtures", "src/**/fixtures*/**", "scripts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       react-native-boost:
         specifier: workspace:*
         version: link:../../packages/react-native-boost
+      react-native-nitro-modules:
+        specifier: 0.35.7
+        version: 0.35.7(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-safe-area-context:
         specifier: ~5.6.0
         version: 5.6.2(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -132,6 +135,9 @@ importers:
       react-native-time-to-render:
         specifier: workspace:*
         version: link:../../packages/react-native-time-to-render
+      react-native-unistyles:
+        specifier: 3.2.5
+        version: 3.2.5(@react-native/normalize-colors@0.83.2)(react-native-nitro-modules@0.35.7(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-web:
         specifier: ^0.21.2
         version: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -808,6 +814,10 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -5888,6 +5898,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-nitro-modules@0.35.7:
+    resolution: {integrity: sha512-3EiU27EmnxTlD3pAXR2OBWeDg7+9tdjKrNQOPX08rFX5hJPNIT/h1i2PjvTUieOypCGTEi9nW/SNBtK3F+4HYg==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-safe-area-context@5.6.2:
     resolution: {integrity: sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==}
     peerDependencies:
@@ -5899,6 +5915,22 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-unistyles@3.2.5:
+    resolution: {integrity: sha512-IiNhQfv98Rhis+fu1CIlTqp1wqAcADkpUmNVSW2stxHkMOU1EkLIyBC50mT/mVTgZugyBJdP9ytUiNJVJkHiWg==}
+    engines: {node: '>= 20.18.0'}
+    peerDependencies:
+      '@react-native/normalize-colors': '*'
+      react: '*'
+      react-native: '>=0.76.0'
+      react-native-edge-to-edge: '*'
+      react-native-nitro-modules: '*'
+      react-native-reanimated: '*'
+    peerDependenciesMeta:
+      react-native-edge-to-edge:
+        optional: true
+      react-native-reanimated:
+        optional: true
 
   react-native-web@0.21.2:
     resolution: {integrity: sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==}
@@ -7620,6 +7652,11 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.7':
     dependencies:
@@ -13237,6 +13274,11 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0)
 
+  react-native-nitro-modules@0.35.7(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0)
+
   react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -13248,6 +13290,14 @@ snapshots:
       react-freeze: 1.0.4(react@19.2.0)
       react-native: 0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0)
       warn-once: 0.1.1
+
+  react-native-unistyles@3.2.5(@react-native/normalize-colors@0.83.2)(react-native-nitro-modules@0.35.7(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@babel/types': 7.29.0
+      '@react-native/normalize-colors': 0.83.2
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0)
+      react-native-nitro-modules: 0.35.7(react-native@0.83.2(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
   react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:


### PR DESCRIPTION
Currently, React Native Boost is incompatible with Unistyles, see issue #58.

This PR adds a `unistyles` mode that routes elements that are provably styled by Unistyles stylesheet to Unistyles' own lean host, keeping reactivity while still skipping React Native's JS-based wrapper. Previously, Boost would optimize elements with unknown sources of `style`. Now, when `unistyles` mode is enabled, React Native Boost bails on components with unresolvable styles (e.g. `props.style` or styles imported from another file), because we can't reliably tell what to rewrite the component to. If `unistyles` mode is not enabled, the previous behavior stays unchanged.

It also fixes a pre-existing bug where descendants of an already-optimized element bailed (a rewritten host was treated as an unknown ancestor), so only the outermost element ever optimized. Nested optimization now cascades correctly.

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unistyles compatibility guidance to the getting started docs and a dedicated setup page.
  * Added an example screen showcasing Unistyles theme switching, responsive styling, and runtime status details.
  * Expanded the sample app navigation to include a new Unistyles demo entry.

* **Bug Fixes**
  * Improved style handling so supported Unistyles and standard React Native cases are optimized correctly.
  * Added safeguards for unsupported or ambiguous styling patterns to avoid incorrect transformations.

* **Documentation**
  * Clarified setup steps for projects using Unistyles or Nativewind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->