### PR TITLE
feat(plugin): transparentWrappers option for design-system passthrough wrappers

### DIFF
--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/code.js
@@ -1,0 +1,13 @@
+import { Text } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="xs">
+    <Text>under view wrapper</Text>
+  </HStack>
+  <Body>
+    <Text>under text wrapper</Text>
+  </Body>
+  <Card>
+    <Text>under unregistered wrapper</Text>
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/output.js
@@ -1,0 +1,13 @@
+import { Text } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="xs">
+    <Text>under view wrapper</Text>
+  </HStack>
+  <Body>
+    <Text>under text wrapper</Text>
+  </Body>
+  <Card>
+    <Text>under unregistered wrapper</Text>
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/transparent-output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/transparent-ds-ancestor/transparent-output.js
@@ -1,0 +1,19 @@
+import {
+  getDefaultTextAccessible as _getDefaultTextAccessible,
+  NativeText as _NativeText,
+} from 'react-native-boost/runtime';
+import { Text } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="xs">
+    <_NativeText allowFontScaling={true} ellipsizeMode={'tail'} accessible={_getDefaultTextAccessible()}>
+      under view wrapper
+    </_NativeText>
+  </HStack>
+  <Body>
+    <Text>under text wrapper</Text>
+  </Body>
+  <Card>
+    <Text>under unregistered wrapper</Text>
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/index.test.ts
@@ -42,6 +42,33 @@ pluginTester({
   })),
 });
 
+// With HStack registered as a 'view' transparent wrapper, the Text under it optimizes; the Text under
+// Body (a 'text' wrapper) bails exactly like under a real Text (it renders as inline virtual text), and
+// the one under the unregistered Card keeps bailing as 'unknown'. The default fixtures run above pins
+// the negative: without the registry, all three bail.
+pluginTester({
+  plugin: generateTestPlugin(textOptimizer, {
+    transparentWrappers: [
+      {
+        module: '@beedeez/front-common-design-system',
+        components: { HStack: 'view', VStack: 'view', Body: 'text' },
+      },
+    ],
+  }),
+  title: 'text transparent wrappers',
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+  tests: [
+    {
+      title: 'optimizes Text under a registered view wrapper only',
+      fixture: path.resolve(import.meta.dirname, 'fixtures/transparent-ds-ancestor/code.js'),
+      outputFixture: path.resolve(import.meta.dirname, 'fixtures/transparent-ds-ancestor/transparent-output.js'),
+    },
+  ],
+});
+
 pluginTester({
   plugin: generateTestPlugin(textOptimizer, { unistyles: true }),
   title: 'text unistyles',

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -122,7 +122,11 @@ export const textOptimizer: Optimizer = (path, logger, options, platform, unisty
       reason: 'contains non-primitive children',
       shouldBail: () => hasInvalidChildren(path, parent),
     },
-    ...ancestorBailoutChecks(path, options?.dangerouslyOptimizeTextWithUnknownAncestors === true),
+    ...ancestorBailoutChecks(
+      path,
+      options?.dangerouslyOptimizeTextWithUnknownAncestors === true,
+      options?.transparentWrappers
+    ),
   ];
 
   if (forced) {

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/code.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/code.js
@@ -1,0 +1,13 @@
+import { View } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="md">
+    <View style={{ flex: 1 }} />
+  </HStack>
+  <Body>
+    <View />
+  </Body>
+  <Card>
+    <View />
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/output.js
@@ -1,0 +1,17 @@
+import { View } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="md">
+    <View
+      style={{
+        flex: 1,
+      }}
+    />
+  </HStack>
+  <Body>
+    <View />
+  </Body>
+  <Card>
+    <View />
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/transparent-output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/fixtures/transparent-ds-ancestor/transparent-output.js
@@ -1,0 +1,18 @@
+import { NativeView as _NativeView } from 'react-native-boost/runtime';
+import { View } from 'react-native';
+import { HStack, Body, Card } from '@beedeez/front-common-design-system';
+<>
+  <HStack spacing="md">
+    <_NativeView
+      style={{
+        flex: 1,
+      }}
+    />
+  </HStack>
+  <Body>
+    <View />
+  </Body>
+  <Card>
+    <View />
+  </Card>
+</>;

--- a/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/__tests__/index.test.ts
@@ -32,6 +32,32 @@ pluginTester({
   ],
 });
 
+// With HStack registered as a 'view' transparent wrapper, the View under it optimizes; the View under
+// Body (a 'text' wrapper) and the one under the unregistered Card keep bailing. The default fixtures
+// run above pins the negative: without the registry, all three bail as 'unknown'.
+pluginTester({
+  plugin: generateTestPlugin(viewOptimizer, {
+    transparentWrappers: [
+      {
+        module: '@beedeez/front-common-design-system',
+        components: { HStack: 'view', VStack: 'view', Body: 'text' },
+      },
+    ],
+  }),
+  title: 'view transparent wrappers',
+  babelOptions: {
+    plugins: ['@babel/plugin-syntax-jsx'],
+  },
+  formatResult: formatTestResult,
+  tests: [
+    {
+      title: 'optimizes View under a registered view wrapper only',
+      fixture: path.resolve(import.meta.dirname, 'fixtures/transparent-ds-ancestor/code.js'),
+      outputFixture: path.resolve(import.meta.dirname, 'fixtures/transparent-ds-ancestor/transparent-output.js'),
+    },
+  ],
+});
+
 pluginTester({
   plugin: generateTestPlugin(viewOptimizer, { unistyles: true }),
   title: 'view unistyles',

--- a/packages/react-native-boost/src/plugin/optimizers/view/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/view/index.ts
@@ -82,7 +82,11 @@ export const viewOptimizer: Optimizer = (path, logger, options, _platform, unist
       reason: 'has both a dynamic `id` and a `nativeID` (ambiguous precedence)',
       shouldBail: () => hasAmbiguousIdNativeID(path),
     },
-    ...ancestorBailoutChecks(path, options?.dangerouslyOptimizeViewWithUnknownAncestors === true),
+    ...ancestorBailoutChecks(
+      path,
+      options?.dangerouslyOptimizeViewWithUnknownAncestors === true,
+      options?.transparentWrappers
+    ),
   ];
 
   if (forced) {

--- a/packages/react-native-boost/src/plugin/types/index.ts
+++ b/packages/react-native-boost/src/plugin/types/index.ts
@@ -13,6 +13,22 @@ export interface PluginOptimizationOptions {
   view?: boolean;
 }
 
+/**
+ * The host kind a transparent wrapper renders to: `'view'` classifies like a React Native `View`
+ * ancestor (normal context), `'text'` like a `Text` ancestor (inline-text context).
+ */
+export type TransparentWrapperHost = 'view' | 'text';
+
+/**
+ * Declares components from one module as transparent passthrough wrappers for ancestor classification.
+ */
+export interface TransparentWrapperEntry {
+  /** npm module specifier the components are imported from, e.g. `'@acme/design-system'`. */
+  module: string;
+  /** Exported name → host kind the wrapper renders to. */
+  components: Record<string, TransparentWrapperHost>;
+}
+
 export interface PluginOptions {
   /**
    * Paths to ignore from optimization.
@@ -79,6 +95,20 @@ export interface PluginOptions {
    * @default false
    */
   dangerouslyOptimizeTextWithUnknownAncestors?: boolean;
+  /**
+   * Treats the listed design-system components as transparent passthrough wrappers during ancestor
+   * classification, instead of bailing on them as `'unknown'` imports.
+   *
+   * A wrapper registered as `'view'` classifies like a React Native `View` ancestor (normal context,
+   * descendants may optimize); one registered as `'text'` classifies like a `Text` ancestor
+   * (inline-text context, descendants bail as they would under a real `Text`).
+   *
+   * Only register a component that renders its children directly into the declared host without
+   * introducing a React Native `Text` wrapper the classification cannot see — a wrong registration
+   * reintroduces exactly the wrong-host risk the ancestor analysis exists to prevent.
+   * @default []
+   */
+  transparentWrappers?: TransparentWrapperEntry[];
 }
 
 export type OptimizableComponent = 'Text' | 'View';

--- a/packages/react-native-boost/src/plugin/utils/common/validation.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/validation.ts
@@ -1,6 +1,6 @@
 import { NodePath, types as t } from '@babel/core';
 import { ensureArray, BailoutCheck } from '../helpers';
-import { HubFile } from '../../types';
+import { HubFile, TransparentWrapperEntry, TransparentWrapperHost } from '../../types';
 import { minimatch } from 'minimatch';
 import nodePath from 'node:path';
 import PluginError from '../plugin-error';
@@ -192,13 +192,18 @@ type AncestorAnalysisContext = {
   componentCache: WeakMap<t.Node, AncestorClassification>;
   componentInProgress: WeakSet<t.Node>;
   renderExpressionInProgress: WeakSet<t.Node>;
+  transparentWrappers: TransparentWrapperEntry[];
 };
 
-export const getAncestorClassification = (path: NodePath<t.JSXOpeningElement>): AncestorClassification => {
+export const getAncestorClassification = (
+  path: NodePath<t.JSXOpeningElement>,
+  transparentWrappers: TransparentWrapperEntry[] = []
+): AncestorClassification => {
   const context: AncestorAnalysisContext = {
     componentCache: new WeakMap<t.Node, AncestorClassification>(),
     componentInProgress: new WeakSet<t.Node>(),
     renderExpressionInProgress: new WeakSet<t.Node>(),
+    transparentWrappers,
   };
 
   let classification: AncestorClassification = 'safe';
@@ -229,10 +234,11 @@ export const getAncestorClassification = (path: NodePath<t.JSXOpeningElement>): 
  */
 export const ancestorBailoutChecks = (
   path: NodePath<t.JSXOpeningElement>,
-  dangerousOptimizationEnabled: boolean
+  dangerousOptimizationEnabled: boolean,
+  transparentWrappers: TransparentWrapperEntry[] = []
 ): BailoutCheck[] => {
   let classification: AncestorClassification | undefined;
-  const classify = () => (classification ??= getAncestorClassification(path));
+  const classify = () => (classification ??= getAncestorClassification(path, transparentWrappers));
 
   return [
     {
@@ -311,13 +317,16 @@ function classifyJSXMemberExpressionAsAncestor(
 
 function classifyBindingAsAncestor(binding: ScopeBinding, context: AncestorAnalysisContext): AncestorClassification {
   if (binding.kind === 'module') {
-    return classifyModuleBindingAsAncestor(binding);
+    return classifyModuleBindingAsAncestor(binding, context);
   }
 
   return classifyLocalBindingAsAncestor(binding, context);
 }
 
-function classifyModuleBindingAsAncestor(binding: ScopeBinding): AncestorClassification {
+function classifyModuleBindingAsAncestor(
+  binding: ScopeBinding,
+  context: AncestorAnalysisContext
+): AncestorClassification {
   const importDeclaration = binding.path.parent;
   if (!t.isImportDeclaration(importDeclaration)) return 'unknown';
 
@@ -349,7 +358,37 @@ function classifyModuleBindingAsAncestor(binding: ScopeBinding): AncestorClassif
     if (importedName === 'Fragment') return 'safe';
   }
 
+  // A component the user registered as a transparent passthrough wrapper classifies by the host it
+  // declares — 'view' establishes a normal context like a real View, 'text' an inline-text context
+  // like a real Text. Matched on the *imported* name (alias-proof), named imports only.
+  if (t.isImportSpecifier(binding.path.node)) {
+    const importedName = getImportSpecifierImportedName(binding.path.node);
+    if (importedName) {
+      const transparentHost = resolveTransparentWrapper(source, importedName, context.transparentWrappers);
+      if (transparentHost === 'view') return 'safe';
+      if (transparentHost === 'text') return 'text';
+    }
+  }
+
   return 'unknown';
+}
+
+/**
+ * Looks up an imported component in the user-registered transparent wrapper entries. Returns the host
+ * kind the wrapper renders to, or `undefined` when the (module, export) pair is not registered.
+ */
+function resolveTransparentWrapper(
+  source: string,
+  importedName: string,
+  entries: TransparentWrapperEntry[]
+): TransparentWrapperHost | undefined {
+  for (const entry of entries) {
+    if (entry.module !== source) continue;
+    const host = entry.components[importedName];
+    if (host) return host;
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds a `transparentWrappers` plugin option that lets users register design-system components as transparent passthrough wrappers for ancestor classification.

## Motivation

Design systems commonly wrap `View`/`Text` in thin passthrough components (`HStack`, `VStack`, typography components) that render children straight into the host without introducing a React Native `Text` wrapper. Today, any `View`/`Text` under such a component classifies as having an `'unknown'` ancestor and bails out — even though the wrapper is provably safe by construction.

The existing escape hatches (`dangerouslyOptimize*WithUnknownAncestors`) are all-or-nothing and unsafe by design. `transparentWrappers` is the targeted alternative: the user vouches for specific (module, export) pairs and declares which host they render to.

At Beedeez (React Native app, ~2 100 source files, design-system based UI), registering 8 wrapper components removed every "unresolved ancestor" bail under our stacks/typography wrappers with no behavioral change, verified on device.

## API

```js
[
  'react-native-boost/plugin',
  {
    transparentWrappers: [
      {
        module: '@acme/design-system',
        components: {
          HStack: 'view', // classifies like a View ancestor
          Body: 'text',   // classifies like a Text ancestor (inline context, still bails)
        },
      },
    ],
  },
]
```

- `'view'` → descendants classify the wrapper as `'safe'`, like a real `View`
- `'text'` → descendants classify it as `'text'`, like a real `Text` (so nested elements correctly keep bailing)
- Matching is on the *imported* name (alias-proof), named imports only
- Unregistered components keep the existing `'unknown'` behavior

## Tests

- New `transparent-ds-ancestor` fixtures for both optimizers:
  - registered `'view'` wrapper → child optimizes
  - registered `'text'` wrapper → child bails ("has Text ancestor")
  - unregistered component → keeps bailing (default fixture run pins the negative)
- Full suite passes (371 tests), `tsc --noEmit` clean, `pnpm build` clean

## Notes

- Docs for the option come from the `PluginOptions` JSDoc (AutoOptionSections)
- Out of scope (possible follow-ups): namespace imports, resolving a manifest file shipped by the design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)
