### PR TITLE
Fix Text parity fuzz edge cases

### DIFF
--- a/packages/react-native-boost/src/plugin/__tests__/parity/normalize.ts
+++ b/packages/react-native-boost/src/plugin/__tests__/parity/normalize.ts
@@ -25,5 +25,13 @@ export const flattenStyle = (style: unknown): unknown => {
  * before the clean matters: a trailing `{ key: undefined }` array entry must apply as a last-wins
  * override (then get dropped here) rather than being dropped inside its own element first.
  */
-export const normalize = (props: Record<string, unknown>) =>
-  JSON.parse(JSON.stringify('style' in props ? { ...props, style: flattenStyle(props.style) } : props));
+export const normalize = (props: Record<string, unknown>) => {
+  const normalized = JSON.parse(
+    JSON.stringify('style' in props ? { ...props, style: flattenStyle(props.style) } : props)
+  );
+
+  // benign: native flattening treats a null style like an absent style.
+  if (normalized.style === null) delete normalized.style;
+
+  return normalized;
+};

--- a/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
+++ b/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
@@ -117,6 +117,28 @@ describe('differential parity', () => {
       expect(normalize(boost.props)).toEqual(normalize(wrapper.props));
     });
 
+    it('Text: mixed dynamic style preserves userSelect flatten order', async () => {
+      const jsx = '<Text style={[dynamicStyle, { userSelect: "text" }]} selectable={true}>hello</Text>';
+      const preamble = 'const dynamicStyle = { userSelect: "none" };';
+      const boost = await captureBoost(os, jsx, preamble);
+      expect(boost.optimized).toBe(true);
+      if (!boost.optimized) throw new Error('expected Text mixed style case to optimize');
+      const wrapper = await captureWrapper(os, jsx, preamble);
+      expect(boost.which).toEqual(wrapper.which);
+      expect(normalize(boost.props)).toEqual(normalize(wrapper.props));
+    });
+
+    it('Text: invalid userSelect clobbers selectable with shadowed undefined', async () => {
+      const jsx = '<Text style={{ userSelect: "xyz" }} selectable={true}>hello</Text>';
+      const preamble = 'const undefined = true;';
+      const boost = await captureBoost(os, jsx, preamble);
+      expect(boost.optimized).toBe(true);
+      if (!boost.optimized) throw new Error('expected Text shadowed undefined case to optimize');
+      const wrapper = await captureWrapper(os, jsx, preamble);
+      expect(boost.which).toEqual(wrapper.which);
+      expect(normalize(boost.props)).toEqual(normalize(wrapper.props));
+    });
+
     it.each(VIEW_CASES)('View: %s', async (jsx) => {
       const boost = await captureBoost(os, jsx);
       expect(boost.optimized).toBe(!BAILED_VIEW_CASES.has(jsx));

--- a/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
+++ b/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
@@ -37,6 +37,7 @@ const TEXT_CASES = [
   '<Text aria-hidden={false}>hello</Text>',
   '<Text aria-hidden accessibilityElementsHidden={false}>hello</Text>',
   '<Text style={{ color: "red" }}>hello</Text>', // styled, no a11y: `accessible` default must survive the build-time style
+  '<Text style={null} adjustsFontSizeToFit={false}>hello</Text>',
   '<Text style={{ color: "red" }} accessibilityLabel="x">hello</Text>',
   // `selectionColor` runs through `processColor` (a non-identity mock packs "red" → an int), so both
   // sides must emit the packed value — proving Boost calls processColor, not a raw forward.
@@ -46,6 +47,7 @@ const TEXT_CASES = [
   '<Text style={{ fontWeight: 700 }}>hello</Text>', // numeric fontWeight → string
   '<Text style={{ verticalAlign: "middle" }}>hello</Text>', // verticalAlign → textAlignVertical
   '<Text style={{ userSelect: "none", color: "red" }}>hello</Text>', // userSelect → selectable
+  '<Text style={{ userSelect: "xyz", fontWeight: 400 }} selectable={true}>hello</Text>',
   '<Text style={[{ color: "red" }, { fontSize: 16 }]}>hello</Text>', // array merged (last wins)
   // `id` → `nativeID` build-time rename; `id` wins over an explicit `nativeID`.
   '<Text id="x">hello</Text>',

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -330,12 +330,14 @@ function processProps(
   // `passStyleByIdentity` (Unistyles routing) skips all style transforms — the original `style`
   // attribute is left untouched in the collected attributes below so it reaches the native host intact.
   if (styleExpr && !passStyleByIdentity) {
-    const selectableValue = extractSelectableAndUpdateStyle(styleExpr);
+    const selectable = extractSelectableAndUpdateStyle(styleExpr);
 
-    if (selectableValue != null) {
+    if (selectable) {
       selectableAttribute = t.jsxAttribute(
         t.jsxIdentifier('selectable'),
-        t.jsxExpressionContainer(t.booleanLiteral(selectableValue))
+        t.jsxExpressionContainer(
+          selectable.value === undefined ? t.identifier('undefined') : t.booleanLiteral(selectable.value)
+        )
       );
     }
 

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -336,7 +336,9 @@ function processProps(
       selectableAttribute = t.jsxAttribute(
         t.jsxIdentifier('selectable'),
         t.jsxExpressionContainer(
-          selectable.value === undefined ? t.identifier('undefined') : t.booleanLiteral(selectable.value)
+          selectable.value === undefined
+            ? t.unaryExpression('void', t.numericLiteral(0))
+            : t.booleanLiteral(selectable.value)
         )
       );
     }

--- a/packages/react-native-boost/src/plugin/utils/common/attributes.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/attributes.ts
@@ -428,23 +428,35 @@ const removeUserSelectProperties = (objectExpr: t.ObjectExpression) => {
  */
 export function extractSelectableAndUpdateStyle(styleExpr: t.Expression): SelectableExtraction | undefined {
   const candidates: Array<{ object: t.ObjectExpression; value: t.Expression }> = [];
+  let hasUnresolvedStylePart = false;
+
   const collect = (objectExpr: t.ObjectExpression) => {
     for (const property of objectExpr.properties) {
-      if (t.isObjectProperty(property) && isUserSelectProperty(property) && t.isExpression(property.value)) {
+      if (!t.isObjectProperty(property) || property.computed) {
+        hasUnresolvedStylePart = true;
+        continue;
+      }
+      if (isUserSelectProperty(property) && t.isExpression(property.value)) {
         candidates.push({ object: objectExpr, value: property.value });
       }
     }
   };
 
-  if (t.isObjectExpression(styleExpr)) {
-    collect(styleExpr);
-  } else if (t.isArrayExpression(styleExpr)) {
-    for (const element of styleExpr.elements) {
-      if (element && t.isObjectExpression(element)) collect(element);
+  const visitStyle = (expr: t.Expression | t.SpreadElement | null) => {
+    if (expr == null) return;
+    if (t.isObjectExpression(expr)) {
+      collect(expr);
+      return;
     }
-  } else {
-    return undefined;
-  }
+    if (t.isArrayExpression(expr)) {
+      for (const element of expr.elements) visitStyle(element);
+      return;
+    }
+    if (!isSkippableFalsyElement(expr)) hasUnresolvedStylePart = true;
+  };
+
+  visitStyle(styleExpr);
+  if (hasUnresolvedStylePart) return undefined;
 
   const last = candidates.at(-1);
   if (!last || isNullishExpression(last.value) || !canResolveUserSelect(last.value)) return undefined;

--- a/packages/react-native-boost/src/plugin/utils/common/attributes.ts
+++ b/packages/react-native-boost/src/plugin/utils/common/attributes.ts
@@ -401,59 +401,59 @@ export function extractSelectionColor(attributes: Array<t.JSXAttribute | t.JSXSp
   return {};
 }
 
+type SelectableExtraction = { value: boolean | undefined };
+
+const isUserSelectProperty = (property: t.ObjectProperty): boolean =>
+  t.isIdentifier(property.key, { name: 'userSelect' }) ||
+  (t.isStringLiteral(property.key) && property.key.value === 'userSelect');
+
+const isNullishExpression = (expression: t.Expression): boolean =>
+  t.isNullLiteral(expression) || t.isIdentifier(expression, { name: 'undefined' });
+
+const canResolveUserSelect = (expression: t.Expression): boolean =>
+  t.isStringLiteral(expression) || t.isNumericLiteral(expression) || t.isBooleanLiteral(expression);
+
+const removeUserSelectProperties = (objectExpr: t.ObjectExpression) => {
+  objectExpr.properties = objectExpr.properties.filter(
+    (property) => !t.isObjectProperty(property) || !isUserSelectProperty(property)
+  );
+};
+
 /**
- * Attempts to statically extract the `userSelect` style property from a style expression.
+ * Attempts to statically extract the final flattened `userSelect` style value from a style expression.
  *
- * If the `userSelect` value can be resolved at compile-time, the property is removed from the
- * object literal (or array element) and its mapped boolean value for the native `selectable`
- * prop is returned. When the value is unknown or the expression is not statically analysable,
- * `undefined` is returned and no modification is made.
+ * A non-null `userSelect` always overrides the direct `selectable` prop in RN, even when the value is
+ * unknown to RN's map and therefore resolves to `undefined`. Dynamic/nullish values are left for the
+ * runtime helper so it can preserve RN's `processedStyle.userSelect != null` check.
  */
-function extractSelectableFromObjectExpression(objectExpr: t.ObjectExpression): boolean | undefined {
-  let selectableValue: boolean | undefined;
-
-  objectExpr.properties = objectExpr.properties.filter((property) => {
-    if (
-      !t.isObjectProperty(property) ||
-      (!t.isIdentifier(property.key, { name: 'userSelect' }) &&
-        !(t.isStringLiteral(property.key) && property.key.value === 'userSelect'))
-    ) {
-      return true; // keep property
-    }
-
-    if (t.isStringLiteral(property.value)) {
-      const mapped = USER_SELECT_STYLE_TO_SELECTABLE_PROP[property.value.value];
-      if (mapped !== undefined) {
-        selectableValue = mapped;
+export function extractSelectableAndUpdateStyle(styleExpr: t.Expression): SelectableExtraction | undefined {
+  const candidates: Array<{ object: t.ObjectExpression; value: t.Expression }> = [];
+  const collect = (objectExpr: t.ObjectExpression) => {
+    for (const property of objectExpr.properties) {
+      if (t.isObjectProperty(property) && isUserSelectProperty(property) && t.isExpression(property.value)) {
+        candidates.push({ object: objectExpr, value: property.value });
       }
     }
+  };
 
-    // Remove the `userSelect` property
-    return false;
-  });
-
-  return selectableValue;
-}
-
-export function extractSelectableAndUpdateStyle(styleExpr: t.Expression): boolean | undefined {
   if (t.isObjectExpression(styleExpr)) {
-    return extractSelectableFromObjectExpression(styleExpr);
-  }
-
-  if (t.isArrayExpression(styleExpr)) {
-    let selectableValue: boolean | undefined;
+    collect(styleExpr);
+  } else if (t.isArrayExpression(styleExpr)) {
     for (const element of styleExpr.elements) {
-      if (element && t.isObjectExpression(element)) {
-        const value = extractSelectableFromObjectExpression(element);
-        if (value !== undefined) {
-          selectableValue = value; // prefer last defined value
-        }
-      }
+      if (element && t.isObjectExpression(element)) collect(element);
     }
-    return selectableValue;
+  } else {
+    return undefined;
   }
 
-  return undefined; // not statically analysable
+  const last = candidates.at(-1);
+  if (!last || isNullishExpression(last.value) || !canResolveUserSelect(last.value)) return undefined;
+
+  for (const { object } of candidates) removeUserSelectProperties(object);
+
+  return {
+    value: t.isStringLiteral(last.value) ? USER_SELECT_STYLE_TO_SELECTABLE_PROP[last.value.value] : undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
Fixes #72
Fixes #74

## Summary
- normalize `style: null` as host-equivalent to absent style in parity comparisons
- make static `style.userSelect` clobber direct `selectable` even when the value maps to `undefined`
- add deterministic parity cases for both fuzz findings

## Validation
- parity test suite
- parity fuzz gate
- Text optimizer tests
- typecheck
- format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of text styles so `null` and unknown selectable states are treated more consistently.
  * Better preserves the last applicable style value when multiple style objects are combined.
  * Updated text rendering behavior to avoid dropping or misapplying selectable-related props in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->