### PR TITLE
preserve style selectable precedence

### DIFF
--- a/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
+++ b/packages/react-native-boost/src/plugin/__tests__/parity/parity.test.ts
@@ -139,6 +139,18 @@ describe('differential parity', () => {
       expect(normalize(boost.props)).toEqual(normalize(wrapper.props));
     });
 
+    it('Text: static userSelect overrides selectable from a later spread', async () => {
+      const jsx =
+        '<Text aria-disabled={_b0} style={{ verticalAlign: "middle", fontWeight: 400, userSelect: "none", width: 10 }} selectionColor={"blue"} {..._s0}>hello</Text>';
+      const preamble = 'const _b0 = false;\nconst _s0 = { selectable: true };';
+      const boost = await captureBoost(os, jsx, preamble);
+      expect(boost.optimized).toBe(true);
+      if (!boost.optimized) throw new Error('expected Text static userSelect spread case to optimize');
+      const wrapper = await captureWrapper(os, jsx, preamble);
+      expect(boost.which).toEqual(wrapper.which);
+      expect(normalize(boost.props)).toEqual(normalize(wrapper.props));
+    });
+
     it.each(VIEW_CASES)('View: %s', async (jsx) => {
       const boost = await captureBoost(os, jsx);
       expect(boost.optimized).toBe(!BAILED_VIEW_CASES.has(jsx));

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/static-style-user-select-overrides-selectable/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/static-style-user-select-overrides-selectable/output.js
@@ -4,11 +4,11 @@ import {
 } from 'react-native-boost/runtime';
 import { Text } from 'react-native';
 <_NativeText
-  selectable={true}
   style={{
     color: 'red',
   }}
   allowFontScaling={true}
   ellipsizeMode={'tail'}
+  selectable={true}
   accessible={_getDefaultTextAccessible()}
 />;

--- a/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/static-style-user-select/output.js
+++ b/packages/react-native-boost/src/plugin/optimizers/text/__tests__/fixtures/static-style-user-select/output.js
@@ -4,11 +4,11 @@ import {
 } from 'react-native-boost/runtime';
 import { Text } from 'react-native';
 <_NativeText
-  selectable={false}
   style={{
     color: 'red',
   }}
   allowFontScaling={true}
   ellipsizeMode={'tail'}
+  selectable={false}
   accessible={_getDefaultTextAccessible()}
 />;

--- a/packages/react-native-boost/src/plugin/optimizers/text/index.ts
+++ b/packages/react-native-boost/src/plugin/optimizers/text/index.ts
@@ -427,16 +427,16 @@ function processProps(
   // ============================================
   // 4. Assemble the final attribute list
   // ============================================
-  // `styleSpread` (the runtime `processTextStyle` call) is emitted AFTER the direct attributes so a
-  // `userSelect`-derived `selectable` it computes at runtime overrides a direct `selectable`, mirroring
-  // `Text`'s late `userSelect` override. `selectionColorSpread` writes a disjoint key (`selectionColor`),
-  // so its position is free — it leads for readability.
+  // `selectableAttribute` and `styleSpread` are emitted AFTER the remaining attributes so style-derived
+  // `userSelect` overrides direct or spread-carried `selectable`, mirroring `Text`'s late override.
+  // `selectionColorSpread` writes a disjoint key (`selectionColor`), so its position is free — it leads
+  // for readability.
   path.node.attributes = [
     selectionColorSpread,
     accessibilitySpread,
-    selectableAttribute,
     staticStyleAttribute,
     ...remainingAttributes,
+    selectableAttribute,
     styleSpread,
     accessibleAttribute,
   ].filter((attribute): attribute is t.JSXAttribute | t.JSXSpreadAttribute => attribute !== undefined);


### PR DESCRIPTION
## Summary

Nightly build on my fork failed: https://github.com/adamivancza/react-native-boost/actions/runs/28921814048

Fixes a parity fuzz divergence where static `style.userSelect` did not override `selectable` from a later spread.

React Native Text applies `userSelect` as a late style-derived override, so:

```tsx
<Text style={{ userSelect: 'none' }} {...{ selectable: true }} />
```

should end up with `selectable={false}`.

Boost already handled the dynamic `processTextStyle(...)` path this way, but the static build-time `selectable` attribute was emitted too early and could be overwritten by later props/spreads.

## Changes

* Emit static userSelect-derived selectable after remaining attributes/spreads
* Add the exact fuzz-discovered parity case
* Update Text fixture output order

## Verification

`pnpm package test text`
`pnpm package test parity`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how text selection-related props are handled so later overrides behave consistently.
  * Fixed optimized text output to match standard rendering, including prop order and native prop values.
  * Added coverage for a scenario where static text selection settings are combined with later prop spreads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->